### PR TITLE
Direct download button, WebView-sniff playback, Watch Later / Watched

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -33,6 +33,10 @@ class AppConstants {
   static const String favoritesBox = 'favorites_box';
   static const String privateFavoritesBox = 'private_favorites_box';
 
+  /// Offline cache for the user-curated lists (`Watch Later` / `Watched`).
+  /// One box, keyed by list slug — the lists share a shape, so they share a box.
+  static const String userListsBox = 'user_lists_box';
+
   static const String accessTokenKey = 'access_token';
   static const String refreshTokenKey = 'refresh_token';
   static const String userKey = 'user';

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -117,6 +117,9 @@ import 'package:soplay/features/trivia/presentation/bloc/topfans/top_fans_bloc.d
 import 'package:soplay/features/detail/presentation/blocs/favorite_bloc/favorite_bloc.dart';
 import 'package:soplay/features/my_list/data/datasources/my_list_local_data_source.dart';
 import 'package:soplay/features/my_list/data/datasources/my_list_remote_data_source.dart';
+import 'package:soplay/features/user_lists/data/datasources/user_lists_remote_data_source.dart';
+import 'package:soplay/features/user_lists/data/repositories/user_lists_repository_impl.dart';
+import 'package:soplay/features/user_lists/domain/repositories/user_lists_repository.dart';
 import 'package:soplay/features/my_list/data/private_list_service.dart';
 import 'package:soplay/features/my_list/data/repositories/my_list_repository_impl.dart';
 import 'package:soplay/features/my_list/domain/repositories/my_list_repository.dart';
@@ -360,6 +363,18 @@ Future<void> configureDependencies() async {
       getIt<HiveService>(),
     ),
   );
+  // User-curated lists (Watch Later / Watched). One repository serves both —
+  // the kind is a parameter, mirroring the server's single handler.
+  getIt.registerSingleton<UserListsRemoteDataSource>(
+    UserListsRemoteDataSource(dio: getIt<Dio>()),
+  );
+  getIt.registerSingleton<UserListsRepository>(
+    UserListsRepositoryImpl(
+      getIt<UserListsRemoteDataSource>(),
+      getIt<HiveService>(),
+    ),
+  );
+
   getIt.registerSingleton<GetFavoritesUseCase>(
     GetFavoritesUseCase(getIt<MyListRepository>()),
   );

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -38,6 +38,8 @@ import 'package:soplay/features/trivia/presentation/pages/leaderboard_page.dart'
 import 'package:soplay/features/trivia/presentation/pages/result_page.dart';
 import 'package:soplay/features/trivia/presentation/pages/top_fans_page.dart';
 import 'package:soplay/features/trivia/presentation/trivia_args.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+import 'package:soplay/features/user_lists/presentation/pages/user_lists_page.dart';
 import 'package:soplay/features/profile/presentation/pages/player_settings_page.dart';
 import 'package:soplay/features/profile/presentation/pages/profile_page.dart';
 import 'package:soplay/features/notifications/presentation/pages/notifications_page.dart';
@@ -117,6 +119,13 @@ class AppRouter {
           final args = state.extra as EpisodesArgs;
           return EpisodesPage(args: args);
         },
+      ),
+      // Watch Later / Watched. `extra` optionally carries the tab to open on,
+      // so a shortcut can deep-link straight to one list.
+      GoRoute(
+        path: '/my-lists',
+        builder: (context, state) =>
+            UserListsPage(initialKind: state.extra as UserListKind?),
       ),
       GoRoute(
         path: '/actor',

--- a/lib/features/detail/presentation/pages/detail_page.dart
+++ b/lib/features/detail/presentation/pages/detail_page.dart
@@ -33,6 +33,8 @@ import 'package:soplay/features/tracker/domain/entities/followed_title.dart';
 import 'package:soplay/features/my_list/data/datasources/my_list_local_data_source.dart';
 import 'package:soplay/features/my_list/data/private_list_service.dart';
 import 'package:soplay/features/my_list/domain/entities/favorite_entity.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+import 'package:soplay/features/user_lists/domain/repositories/user_lists_repository.dart';
 import 'package:soplay/features/private_list/presentation/private_unlock.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:soplay/features/detail/presentation/widgets/detail_cast_tab.dart';
@@ -899,6 +901,15 @@ class _DetailViewState extends State<_DetailView>
                             showPill: showPill,
                             title: detail.title,
                             reader: detail.provider.opensReader,
+                            // Identity for the Watch Later / Watched buttons.
+                            // Those talk to UserListsRepository themselves, so
+                            // they need the content, not another callback pair.
+                            listEntity: FavoriteEntity(
+                              provider: detail.provider,
+                              contentUrl: detail.contentUrl,
+                              title: detail.title,
+                              thumbnail: detail.thumbnail ?? '',
+                            ),
                             isInList: isInList,
                             inPrivate: inPrivate,
                             isLoading: state is EpisodesLoading,
@@ -966,6 +977,7 @@ class _AnimatedTopBar extends StatelessWidget {
     required this.showPill,
     required this.title,
     required this.reader,
+    required this.listEntity,
     required this.isInList,
     required this.inPrivate,
     required this.isLoading,
@@ -991,6 +1003,9 @@ class _AnimatedTopBar extends StatelessWidget {
 
   /// Reading source — the pill says "Read" rather than "Play".
   final bool reader;
+
+  /// Content identity for the Watch Later / Watched buttons.
+  final FavoriteEntity listEntity;
   final bool isInList;
   final bool inPrivate;
   final bool isLoading;
@@ -1113,6 +1128,20 @@ class _AnimatedTopBar extends StatelessWidget {
                   ),
                   const SizedBox(width: 8),
                 ],
+                _UserListButton(
+                  kind: UserListKind.watchLater,
+                  entity: listEntity,
+                  activeIcon: Icons.watch_later_rounded,
+                  inactiveIcon: Icons.watch_later_outlined,
+                ),
+                const SizedBox(width: 8),
+                _UserListButton(
+                  kind: UserListKind.watched,
+                  entity: listEntity,
+                  activeIcon: Icons.visibility_rounded,
+                  inactiveIcon: Icons.visibility_outlined,
+                ),
+                const SizedBox(width: 8),
                 if (showFollow) ...[
                   _CircleIconButton(
                     icon: isFollowing
@@ -1137,6 +1166,71 @@ class _AnimatedTopBar extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Toggle for one user-curated list (Watch Later / Watched).
+///
+/// Owns its state and talks to [UserListsRepository] directly instead of adding
+/// another callback pair to [_AnimatedTopBar]: the two buttons behave
+/// identically, differ only by [kind], and a third list would be one more
+/// instance rather than more plumbing.
+///
+/// The repository writes its cache before the network, so the flip is immediate
+/// and survives a failed request — no spinner, no rollback dance.
+class _UserListButton extends StatefulWidget {
+  const _UserListButton({
+    required this.kind,
+    required this.entity,
+    required this.activeIcon,
+    required this.inactiveIcon,
+  });
+
+  final UserListKind kind;
+  final FavoriteEntity entity;
+  final IconData activeIcon;
+  final IconData inactiveIcon;
+
+  @override
+  State<_UserListButton> createState() => _UserListButtonState();
+}
+
+class _UserListButtonState extends State<_UserListButton> {
+  late bool _active = _read();
+
+  bool _read() => getIt<UserListsRepository>()
+      .contains(widget.kind, widget.entity.contentUrl);
+
+  @override
+  void didUpdateWidget(covariant _UserListButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The same button is reused when the page rebinds to another title.
+    if (oldWidget.entity.contentUrl != widget.entity.contentUrl) {
+      _active = _read();
+    }
+  }
+
+  Future<void> _toggle() async {
+    final repo = getIt<UserListsRepository>();
+    final next = !_active;
+    setState(() => _active = next);
+    if (next) {
+      await repo.add(widget.kind, widget.entity);
+      // Marking Watched evicts the title from Watch Later (server and cache
+      // both), so the sibling button must re-read rather than stay lit.
+      if (widget.kind == UserListKind.watched && mounted) setState(() {});
+    } else {
+      await repo.remove(widget.kind, widget.entity.contentUrl);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _CircleIconButton(
+      icon: _active ? widget.activeIcon : widget.inactiveIcon,
+      iconColor: _active ? AppColors.rating : Colors.white,
+      onTap: _toggle,
     );
   }
 }

--- a/lib/features/detail/presentation/pages/player_page.controls.dart
+++ b/lib/features/detail/presentation/pages/player_page.controls.dart
@@ -672,6 +672,13 @@ extension _PlayerControls on _PlayerPageState {
     final hasEpisodes = widget.args.isSerial && widget.args.episodes.isNotEmpty;
     final hasQualities = _videoSources.length > 1;
     final hasLangSwitcher = _availableLangsForCurrentEpisode().length > 1;
+    // Same gate the settings-sheet entry uses (player_page.panels.dart): the
+    // top bar only promotes the action, it does not widen who can download.
+    // `_videoUrl` must already be resolved — a download needs the real stream,
+    // not the pending/placeholder state the bar renders during load.
+    final canDownload = widget.args.showDownloadAction &&
+        widget.args.provider != 'uzmovi' &&
+        _videoUrl != null;
     final isBuffering = c != null && c.value.isBuffering;
 
     final overlay = FadeTransition(
@@ -741,6 +748,13 @@ extension _PlayerControls on _PlayerPageState {
                           onTap: _openSubtitleSheet,
                         ),
                         const SizedBox(width: 8),
+                        if (canDownload) ...[
+                          _IconButton(
+                            icon: Icons.download_rounded,
+                            onTap: _startDownload,
+                          ),
+                          const SizedBox(width: 8),
+                        ],
                         _IconButton(
                           icon: Icons.settings_outlined,
                           onTap: _openSettingsSheet,
@@ -781,6 +795,13 @@ extension _PlayerControls on _PlayerPageState {
                           onTap: _enterPip,
                         ),
                         const SizedBox(width: 8),
+                        if (canDownload) ...[
+                          _IconButton(
+                            icon: Icons.download_rounded,
+                            onTap: _startDownload,
+                          ),
+                          const SizedBox(width: 8),
+                        ],
                         _IconButton(
                           icon: Icons.settings_outlined,
                           onTap: _openSettingsSheet,

--- a/lib/features/detail/presentation/pages/player_page.dart
+++ b/lib/features/detail/presentation/pages/player_page.dart
@@ -15,6 +15,7 @@ import 'package:soplay/core/error/result.dart';
 import 'package:soplay/core/player/external_player.dart';
 import 'package:soplay/core/player/local_hls_proxy.dart';
 import 'package:soplay/core/player/player_engine.dart';
+import 'package:soplay/core/player/webview_stream_extractor.dart';
 import 'package:soplay/core/storage/hive_service.dart';
 import 'package:soplay/core/system/app_orientation.dart';
 import 'package:soplay/core/system/desktop_window.dart';
@@ -22,6 +23,7 @@ import 'package:soplay/core/system/responsive.dart';
 import 'package:soplay/core/theme/app_colors.dart';
 import 'package:soplay/features/cloudflare/cloudflare_solver.dart';
 import 'package:soplay/features/detail/domain/entities/episode_entity.dart';
+import 'package:soplay/features/detail/domain/entities/extractor_config_entity.dart';
 import 'package:soplay/features/detail/domain/entities/player_args.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:soplay/core/subtitles/online_subtitles_service.dart';
@@ -108,6 +110,18 @@ class _PlayerPageState extends State<PlayerPage>
   bool _isHls = false;
   bool _isLive = false;
   List<VideoSourceEntity> _videoSources = const [];
+
+  /// Server-sent headless-WebView sniff directive for the CURRENT media, or null.
+  ///
+  /// Held as state rather than threaded through [_initializeWith]'s eight call
+  /// sites: quality switches, party sync and retries all re-enter that method
+  /// and every one of them needs the same directive.
+  ///
+  /// It is a capability description, never a provider name — a source whose real
+  /// manifest only exists once the page's own JS has run carries this, and the
+  /// player treats them all identically. Adding such a provider is a backend-only
+  /// change.
+  ExtractorConfigEntity? _extractorConfig;
   int _currentSourceIndex = -1;
   bool _autoFallbackUsed = false;
   String? _errorMessage;

--- a/lib/features/detail/presentation/pages/player_page.media.dart
+++ b/lib/features/detail/presentation/pages/player_page.media.dart
@@ -113,6 +113,7 @@ extension _PlayerMedia on _PlayerPageState {
           _subtitles = subs;
           _activeSubtitleIndex = -1;
           _captionFile = null;
+          _extractorConfig = value.extractor;
         });
         unawaited(_loadThumbnails(value.thumbnails));
         await _initializeWith(
@@ -247,7 +248,61 @@ extension _PlayerMedia on _PlayerPageState {
     }
   }
 
+  /// Entry point for every playback start. Resolves a page-url source to its
+  /// real manifest first, then hands off to [_initializeResolved].
+  ///
+  /// A wrapper rather than an inline block because all eight call sites (first
+  /// play, episode change, quality switch, party sync, retry, fallback) must go
+  /// through the sniff — putting it here means none of them can forget.
   Future<void> _initializeWith({
+    required String url,
+    required Map<String, String> headers,
+    required String? type,
+    Duration resumeAt = Duration.zero,
+    PartyPlayback? party,
+  }) async {
+    var effUrl = url;
+    var effHeaders = headers;
+    var effType = type;
+
+    // Only when the server sent a directive — no provider check, no url
+    // pattern-matching. See `_extractorConfig`.
+    final cfg = _extractorConfig;
+    if (cfg != null && url.isNotEmpty) {
+      _plog('webview sniff: host=${cfg.hostPattern} patterns=${cfg.urlPatterns}');
+      final sw = Stopwatch()..start();
+      final sniffed = await getIt<WebViewStreamExtractor>().extract(
+        pageUrl: url,
+        config: cfg,
+        pageHeaders: headers,
+      );
+      if (!mounted) return;
+      if (sniffed != null) {
+        effUrl = sniffed.url;
+        // Sniffed headers win: they are the ones the page actually sent, and
+        // the CDN gates on exactly those.
+        effHeaders = {...headers, ...sniffed.headers};
+        effType = sniffed.playType;
+        _plog('sniff ok in ${sw.elapsedMilliseconds}ms -> $effUrl');
+      } else {
+        // Fall through with the page url. It will fail, but with the player's
+        // own error rather than a silent black screen — and the log above says
+        // why. Blanking here would hide a recoverable retry.
+        _plog('sniff found no stream in ${sw.elapsedMilliseconds}ms',
+            level: LogLevel.warn);
+      }
+    }
+
+    await _initializeResolved(
+      url: effUrl,
+      headers: effHeaders,
+      type: effType,
+      resumeAt: resumeAt,
+      party: party,
+    );
+  }
+
+  Future<void> _initializeResolved({
     required String url,
     required Map<String, String> headers,
     required String? type,

--- a/lib/features/my_list/presentation/widgets/my_list_header.dart
+++ b/lib/features/my_list/presentation/widgets/my_list_header.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:soplay/core/system/responsive.dart';
 import 'package:soplay/core/theme/app_colors.dart';
 
@@ -50,6 +51,17 @@ class MyListHeader extends StatelessWidget {
                 height: 1.05,
               ),
             ),
+          ),
+          // Entry point to the curated lists (Watch Later / Watched). They live
+          // on their own page rather than as modes of this one — see
+          // UserListsPage — so this is the only way in.
+          IconButton(
+            tooltip: 'My Lists',
+            icon: const Icon(
+              Icons.playlist_add_check_rounded,
+              color: AppColors.textSecondary,
+            ),
+            onPressed: () => context.push('/my-lists'),
           ),
           if (onRefresh != null)
             DesktopRefreshButton(

--- a/lib/features/user_lists/data/datasources/user_lists_remote_data_source.dart
+++ b/lib/features/user_lists/data/datasources/user_lists_remote_data_source.dart
@@ -1,0 +1,57 @@
+import 'package:dio/dio.dart';
+import 'package:soplay/features/my_list/data/models/favorite_model.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+
+/// Transport for `/auth/lists/<kind>`.
+///
+/// Deliberately parameterised by [UserListKind] rather than one method per
+/// list: the server implements both lists through a single handler, and mirroring
+/// that here keeps the two ends from drifting apart.
+///
+/// Items reuse [FavoriteModel] — the server returns the same
+/// provider/contentUrl/title/thumbnail shape for lists as for favorites, so a
+/// parallel model would be duplication with an extra chance to disagree. The
+/// server's extra `addedAt` is ignored: nothing in the UI orders by it (the list
+/// already arrives newest-first).
+class UserListsRemoteDataSource {
+  const UserListsRemoteDataSource({required this.dio});
+
+  final Dio dio;
+
+  Future<List<FavoriteModel>> getList(UserListKind kind) async {
+    final response = await dio.get('/auth/lists/${kind.slug}');
+    final data = response.data;
+    final items = data is Map ? data['items'] : null;
+    if (items is! List) return const [];
+    return items
+        .whereType<Map>()
+        .map((e) => FavoriteModel.fromJson(e.cast<String, dynamic>()))
+        .where((e) => e.contentUrl.trim().isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Future<void> add(
+    UserListKind kind, {
+    required String provider,
+    required String contentUrl,
+    required String title,
+    required String thumbnail,
+  }) async {
+    await dio.post(
+      '/auth/lists/${kind.slug}',
+      data: {
+        'provider': provider,
+        'contentUrl': contentUrl,
+        'title': title,
+        'thumbnail': thumbnail,
+      },
+    );
+  }
+
+  Future<void> remove(UserListKind kind, String contentUrl) async {
+    await dio.delete(
+      '/auth/lists/${kind.slug}',
+      data: {'contentUrl': contentUrl},
+    );
+  }
+}

--- a/lib/features/user_lists/data/repositories/user_lists_repository_impl.dart
+++ b/lib/features/user_lists/data/repositories/user_lists_repository_impl.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:soplay/core/constants/app_constants.dart';
+import 'package:soplay/core/error/result.dart';
+import 'package:soplay/core/storage/hive_service.dart';
+import 'package:soplay/features/my_list/domain/entities/favorite_entity.dart';
+import 'package:soplay/features/user_lists/data/datasources/user_lists_remote_data_source.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+import 'package:soplay/features/user_lists/domain/repositories/user_lists_repository.dart';
+
+/// Cache-first, server-authoritative.
+///
+/// The same shape [MyListRepositoryImpl] uses, and for the same reason: these
+/// lists are read on screens that must render instantly and must not go blank
+/// on a flaky connection. So every read serves the cache, a successful fetch
+/// replaces it, and a failed fetch leaves the last good copy in place.
+///
+/// Writes are applied to the cache FIRST so the button flips immediately, then
+/// pushed. A failed push leaves the local edit standing — the next successful
+/// [getList] reconciles it against the server, which is the authority.
+class UserListsRepositoryImpl implements UserListsRepository {
+  UserListsRepositoryImpl(this.remote, this.hive);
+
+  final UserListsRemoteDataSource remote;
+  final HiveService hive;
+
+  Box get _box => Hive.box(AppConstants.userListsBox);
+
+  List<FavoriteEntity> _cached(UserListKind kind) {
+    final raw = _box.get(kind.slug);
+    if (raw is! String || raw.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<Map>()
+          .map(
+            (e) => FavoriteEntity(
+              provider: (e['provider'] ?? '').toString(),
+              contentUrl: (e['contentUrl'] ?? '').toString(),
+              title: (e['title'] ?? '').toString(),
+              thumbnail: (e['thumbnail'] ?? '').toString(),
+            ),
+          )
+          .where((e) => e.contentUrl.isNotEmpty)
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<void> _store(UserListKind kind, List<FavoriteEntity> items) async {
+    await _box.put(
+      kind.slug,
+      jsonEncode([
+        for (final e in items)
+          {
+            'provider': e.provider,
+            'contentUrl': e.contentUrl,
+            'title': e.title,
+            'thumbnail': e.thumbnail,
+          },
+      ]),
+    );
+  }
+
+  @override
+  Future<Result<List<FavoriteEntity>>> getList(UserListKind kind) async {
+    // These lists live on the account, so a signed-out user has none. Return
+    // the (empty) cache rather than an error — the UI shows a sign-in prompt.
+    if (!hive.isLoggedIn) return Success(_cached(kind));
+    try {
+      final server = await remote.getList(kind);
+      final items = server
+          .map(
+            (m) => FavoriteEntity(
+              provider: m.provider,
+              contentUrl: m.contentUrl,
+              title: m.title,
+              thumbnail: m.thumbnail,
+            ),
+          )
+          .toList(growable: false);
+      await _store(kind, items);
+      return Success(items);
+    } catch (_) {
+      return Success(_cached(kind));
+    }
+  }
+
+  @override
+  Future<Result<void>> add(UserListKind kind, FavoriteEntity entity) async {
+    final next = [
+      entity,
+      ..._cached(kind).where((e) => e.contentUrl != entity.contentUrl),
+    ];
+    await _store(kind, next);
+
+    // Mirror the server's rule: something marked Watched is no longer pending.
+    // Done locally too, or the Watch Later tab would keep showing it until the
+    // next fetch. See addToList in the backend's authService.
+    if (kind == UserListKind.watched) {
+      await _store(
+        UserListKind.watchLater,
+        _cached(
+          UserListKind.watchLater,
+        ).where((e) => e.contentUrl != entity.contentUrl).toList(growable: false),
+      );
+    }
+
+    if (hive.isLoggedIn) {
+      try {
+        await remote.add(
+          kind,
+          provider: entity.provider,
+          contentUrl: entity.contentUrl,
+          title: entity.title,
+          thumbnail: entity.thumbnail,
+        );
+      } catch (_) {
+        // Kept locally; reconciled on the next successful getList.
+      }
+    }
+    return const Success<void>(null);
+  }
+
+  @override
+  Future<Result<void>> remove(UserListKind kind, String contentUrl) async {
+    await _store(
+      kind,
+      _cached(kind).where((e) => e.contentUrl != contentUrl).toList(growable: false),
+    );
+    if (hive.isLoggedIn) {
+      try {
+        await remote.remove(kind, contentUrl);
+      } catch (_) {}
+    }
+    return const Success<void>(null);
+  }
+
+  @override
+  bool contains(UserListKind kind, String contentUrl) =>
+      _cached(kind).any((e) => e.contentUrl == contentUrl);
+}

--- a/lib/features/user_lists/domain/entities/user_list_kind.dart
+++ b/lib/features/user_lists/domain/entities/user_list_kind.dart
@@ -1,0 +1,18 @@
+/// The user-curated lists the backend exposes at `/auth/lists/<slug>`.
+///
+/// One enum drives every layer (data source, repository, UI tabs) so adding a
+/// third list is a single entry here plus a registry line on the server — never
+/// a parallel copy of the feature. [slug] MUST match the server's registry in
+/// `authService.USER_LISTS`.
+enum UserListKind {
+  watchLater('watch-later', 'Watch Later'),
+  watched('watched', 'Watched');
+
+  const UserListKind(this.slug, this.label);
+
+  /// URL segment — the server validates this and 400s on anything unknown.
+  final String slug;
+
+  /// Human label for tabs and buttons.
+  final String label;
+}

--- a/lib/features/user_lists/domain/repositories/user_lists_repository.dart
+++ b/lib/features/user_lists/domain/repositories/user_lists_repository.dart
@@ -1,0 +1,19 @@
+import 'package:soplay/core/error/result.dart';
+import 'package:soplay/features/my_list/domain/entities/favorite_entity.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+
+/// Read/write access to the user-curated lists.
+///
+/// Every method takes the [UserListKind] rather than existing once per list, so
+/// the UI can render a tab per enum value with no per-list branching.
+abstract class UserListsRepository {
+  Future<Result<List<FavoriteEntity>>> getList(UserListKind kind);
+
+  Future<Result<void>> add(UserListKind kind, FavoriteEntity entity);
+
+  Future<Result<void>> remove(UserListKind kind, String contentUrl);
+
+  /// Whether [contentUrl] is already in [kind] — drives the detail page's
+  /// button state. Answered from the cache so it never blocks a page render.
+  bool contains(UserListKind kind, String contentUrl);
+}

--- a/lib/features/user_lists/presentation/pages/user_lists_page.dart
+++ b/lib/features/user_lists/presentation/pages/user_lists_page.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:soplay/core/di/injection.dart';
+import 'package:soplay/core/theme/app_colors.dart';
+import 'package:soplay/features/my_list/domain/entities/favorite_entity.dart';
+import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
+import 'package:soplay/features/user_lists/domain/repositories/user_lists_repository.dart';
+
+/// The user's curated lists, one tab per [UserListKind].
+///
+/// A page of its own rather than another mode inside `MyListPage`: that page is
+/// driven by `MyListBloc` around a single favorites source, and threading two
+/// more sources through it would couple three independent lists to one bloc.
+/// Tabs are generated from the enum, so a third list needs no code here.
+class UserListsPage extends StatefulWidget {
+  const UserListsPage({super.key, this.initialKind});
+
+  /// Which tab opens first — used when arriving from a "Watch Later" shortcut.
+  final UserListKind? initialKind;
+
+  @override
+  State<UserListsPage> createState() => _UserListsPageState();
+}
+
+class _UserListsPageState extends State<UserListsPage>
+    with SingleTickerProviderStateMixin {
+  static const _kinds = UserListKind.values;
+
+  late final TabController _tabs = TabController(
+    length: _kinds.length,
+    vsync: this,
+    initialIndex: widget.initialKind == null
+        ? 0
+        : _kinds.indexOf(widget.initialKind!).clamp(0, _kinds.length - 1),
+  );
+
+  @override
+  void dispose() {
+    _tabs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        title: const Text('My Lists'),
+        bottom: TabBar(
+          controller: _tabs,
+          indicatorColor: AppColors.primary,
+          tabs: [for (final k in _kinds) Tab(text: k.label)],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabs,
+        children: [for (final k in _kinds) _UserListTab(kind: k)],
+      ),
+    );
+  }
+}
+
+class _UserListTab extends StatefulWidget {
+  const _UserListTab({required this.kind});
+
+  final UserListKind kind;
+
+  @override
+  State<_UserListTab> createState() => _UserListTabState();
+}
+
+class _UserListTabState extends State<_UserListTab>
+    with AutomaticKeepAliveClientMixin {
+  late Future<List<FavoriteEntity>> _future = _load();
+
+  @override
+  bool get wantKeepAlive => true;
+
+  Future<List<FavoriteEntity>> _load() async {
+    final result = await getIt<UserListsRepository>().getList(widget.kind);
+    return result.getOrNull() ?? const [];
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _future = _load());
+    await _future;
+  }
+
+  Future<void> _remove(FavoriteEntity item) async {
+    await getIt<UserListsRepository>().remove(widget.kind, item.contentUrl);
+    await _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return FutureBuilder<List<FavoriteEntity>>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final items = snapshot.data ?? const <FavoriteEntity>[];
+        if (items.isEmpty) {
+          // The repository never surfaces an error — a failed fetch falls back
+          // to the cache — so "empty" is the only empty-ish state there is.
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              children: [
+                const SizedBox(height: 120),
+                Center(
+                  child: Text(
+                    'Nothing in ${widget.kind.label} yet',
+                    style: const TextStyle(color: Colors.white70),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+        return RefreshIndicator(
+          onRefresh: _refresh,
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: items.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final item = items[i];
+              return ListTile(
+                leading: item.thumbnail.isEmpty
+                    ? const SizedBox(width: 44)
+                    : ClipRRect(
+                        borderRadius: BorderRadius.circular(6),
+                        child: Image.network(
+                          item.thumbnail,
+                          width: 44,
+                          height: 62,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, _, _) => const SizedBox(width: 44),
+                        ),
+                      ),
+                title: Text(
+                  item.title.isEmpty ? item.contentUrl : item.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Colors.white),
+                ),
+                subtitle: Text(
+                  item.provider,
+                  style: const TextStyle(color: Colors.white54, fontSize: 12),
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.close_rounded, color: Colors.white54),
+                  onPressed: () => _remove(item),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -158,6 +158,7 @@ Future<void> _initHive() async {
     Hive.openBox(AppConstants.extractorsBox),
     Hive.openBox(AppConstants.streakBox),
     Hive.openBox(AppConstants.favoritesBox),
+    Hive.openBox(AppConstants.userListsBox),
     Hive.openBox(AppConstants.privateFavoritesBox),
   ]);
 }


### PR DESCRIPTION
Three independent features, one commit each.

## 1. Direct download button (`8069e4f`)

Reported as "please add a direct download button" — the action already existed but was buried in the player's settings sheet, so users never found it. Now on the control bar for both phone and TV layouts, behind the **same gate** as the sheet entry (`showDownloadAction && provider != 'uzmovi' && _videoUrl != null`): the bar only promotes it, it does not widen who can download.

## 2. WebView-sniff playback (`451a940`)

Some sources resolve to an HTML page, not a stream — the real manifest only exists once the page's own JS has run. `_initializeWith` now resolves that first, then delegates to `_initializeResolved`.

A wrapper rather than an inline block because **all eight call sites** (first play, episode change, quality switch, party sync, retry, fallback) must go through it — this way none of them can forget.

Driven purely by the server's `extractor` directive — no provider check, no URL pattern-matching — so a new provider of this kind ships **without an app update**.

Note: `WebViewStreamExtractor` already existed and was registered in DI, but nothing ever called it. This wires it up. A failed sniff falls through with the page url so the player's own error and retry still apply, instead of a silent black screen.

Pairs with sozo-backend#1.

## 3. Watch Later / Watched (`668938e`)

Requested as sections users can organise manually — distinct from the existing bookmarks and from the automatic history.

- `/my-lists` page, one tab per list, generated from the enum
- Two toggles on the detail page (clock = Watch Later, eye = Watched)
- Entry point from the "My List" header

**Cache-first, server-authoritative.** Reads serve the cache instantly; a successful fetch replaces it; a failed fetch leaves the last good copy, so a curated list never goes blank on a flaky connection. Writes hit the cache first, so the button flips immediately and survives a failed request — reconciled on the next successful fetch.

Marking Watched evicts from Watch Later locally too, matching the server, or that tab would keep showing the title until the next fetch.

One feature parameterised by list kind rather than two copies, mirroring the server's single handler — a third list is one enum entry.

Requires the endpoints in sozo-backend#1.

## Verification

`flutter analyze` clean across all touched files. The two pre-existing project warnings (`hive` dep in `extensions`, deprecated `onReorder` in `profile`) are untouched and unrelated.

Not run on a device — please check the two new detail-page buttons and the `/my-lists` tabs.