### PR TITLE
fix(cloudstream): play Live TV channels, and say why when nothing is …

### DIFF
--- a/android/app/src/main/kotlin/com/soplay/sozo/cloudstream/PluginHost.kt
+++ b/android/app/src/main/kotlin/com/soplay/sozo/cloudstream/PluginHost.kt
@@ -7,10 +7,12 @@ import android.util.Log
 import com.lagradost.cloudstream3.APIHolder
 import com.lagradost.cloudstream3.AnimeLoadResponse
 import com.lagradost.cloudstream3.Episode
+import com.lagradost.cloudstream3.LiveStreamLoadResponse
 import com.lagradost.cloudstream3.MainAPI
 import com.lagradost.cloudstream3.MainPageRequest
 import com.lagradost.cloudstream3.MovieLoadResponse
 import com.lagradost.cloudstream3.SearchResponse
+import com.lagradost.cloudstream3.TorrentLoadResponse
 import com.lagradost.cloudstream3.TvSeriesLoadResponse
 import com.lagradost.cloudstream3.plugins.BasePlugin
 import com.lagradost.cloudstream3.plugins.Plugin
@@ -340,6 +342,7 @@ class PluginHost(private val appContext: Context) {
         } ?: return "{}"
         val episodes = JSONArray()
         var isSerial = false
+        var unsupported: String? = null
         when (resp) {
             is TvSeriesLoadResponse -> {
                 isSerial = true
@@ -357,6 +360,25 @@ class PluginHost(private val appContext: Context) {
                 episodes.put(JSONObject().apply {
                     put("episode", 1); put("label", "Play"); put("mediaRef", ref)
                 })
+            }
+            // Live TV channels. Structurally identical to a movie — one `dataUrl`
+            // handed straight to loadLinks — but it is a SEPARATE response class,
+            // and leaving it out of this `when` is why every Live TV plugin
+            // (IPTVPlayer, QuickIPTV, PublicSportsIPTV, …) opened to a detail page
+            // with no episodes and nothing to press: `load()` succeeded, the title
+            // and poster rendered, and the playable entry was silently dropped.
+            is LiveStreamLoadResponse -> {
+                val ref = resp.dataUrl.ifEmpty { resp.url }
+                episodes.put(JSONObject().apply {
+                    put("episode", 1); put("label", "Watch live"); put("mediaRef", ref)
+                })
+            }
+            // Torrent/magnet entries have no dataUrl and no HTTP stream — there is
+            // nothing this app's player can do with them. Say so explicitly rather
+            // than rendering the same silent empty page.
+            is TorrentLoadResponse -> {
+                unsupported =
+                    "This is a torrent entry (magnet link) — Sozo's player cannot open it."
             }
         }
         // Cast (actors) + related (recommendations) when the provider supplies them.
@@ -399,6 +421,13 @@ class PluginHost(private val appContext: Context) {
             put("cast", cast)
             put("related", related)
             put("episodes", episodes)
+            // An empty episode list is never something the UI can act on, so
+            // always say why. Previously this returned a valid-looking payload
+            // with zero entries and the detail page just sat there.
+            if (episodes.length() == 0) {
+                put("error", unsupported
+                    ?: "${'$'}{api.name}: no playable entry for this title (${'$'}{resp.javaClass.simpleName})")
+            }
         }.toString()
     }
 

--- a/lib/features/detail/data/repositories/detail_repository_impl.dart
+++ b/lib/features/detail/data/repositories/detail_repository_impl.dart
@@ -99,6 +99,29 @@ class DetailRepositoryImpl implements DetailRepository {
     }
   }
 
+  /// Maps an on-device host's `load()` payload to a playback result.
+  ///
+  /// The hosts set an `error` field when they produced a page but nothing
+  /// playable — a Live TV response type they don't map, a torrent-only entry, a
+  /// source whose apk failed to link. Without reading it the caller just sees an
+  /// empty episode list and shows a generic "no episodes", which is
+  /// indistinguishable from a title that genuinely has none.
+  Result<PlaybackModel> _playbackFrom(
+    Map<String, dynamic> map,
+    String label,
+    String sort,
+  ) {
+    if (map.isEmpty) return Failure(Exception('$label: source unavailable'));
+    final model = PlaybackModel.fromJson(map);
+    if (model.episodes.isEmpty) {
+      final err = map['error'];
+      return Failure(Exception(
+        err is String && err.isNotEmpty ? '$label: $err' : '$label: nothing to play',
+      ));
+    }
+    return Success(_applySort(model, sort));
+  }
+
   @override
   Future<Result<PlaybackEntity>> getEpisodes(
     String contentUrl, {
@@ -112,10 +135,7 @@ class DetailRepositoryImpl implements DetailRepository {
     if (effective != null && effective.startsWith('cs:')) {
       try {
         final map = await CloudStreamChannel.load(effective.substring(3), contentUrl);
-        if (map.isNotEmpty) {
-          return Success(_applySort(PlaybackModel.fromJson(map), sort));
-        }
-        return Failure(Exception('CloudStream: episodes not found'));
+        return _playbackFrom(map, 'CloudStream', sort);
       } catch (e) {
         return Failure(Exception(_normalizeJsError(e)));
       }
@@ -123,10 +143,7 @@ class DetailRepositoryImpl implements DetailRepository {
     if (effective != null && effective.startsWith('an:')) {
       try {
         final map = await AniyomiChannel.load(effective.substring(3), contentUrl);
-        if (map.isNotEmpty) {
-          return Success(_applySort(PlaybackModel.fromJson(map), sort));
-        }
-        return Failure(Exception('Aniyomi: episodes not found'));
+        return _playbackFrom(map, 'Aniyomi', sort);
       } catch (e) {
         return Failure(Exception(_normalizeJsError(e)));
       }
@@ -134,10 +151,7 @@ class DetailRepositoryImpl implements DetailRepository {
     if (effective != null && effective.startsWith('mn:')) {
       try {
         final map = await MangaChannel.load(effective.substring(3), contentUrl);
-        if (map.isNotEmpty) {
-          return Success(_applySort(PlaybackModel.fromJson(map), sort));
-        }
-        return Failure(Exception('Manga: chapters not found'));
+        return _playbackFrom(map, 'Manga', sort);
       } catch (e) {
         return Failure(Exception(_normalizeJsError(e)));
       }
@@ -145,10 +159,7 @@ class DetailRepositoryImpl implements DetailRepository {
     if (effective != null && effective.startsWith('my:')) {
       try {
         final map = await mangayomi.load(effective.substring(3), contentUrl);
-        if (map.isNotEmpty) {
-          return Success(_applySort(PlaybackModel.fromJson(map), sort));
-        }
-        return Failure(Exception('Mangayomi: chapters not found'));
+        return _playbackFrom(map, 'Mangayomi', sort);
       } catch (e) {
         return Failure(Exception(_normalizeJsError(e)));
       }


### PR DESCRIPTION
…playable

`loadJson`'s `when (resp)` covered TvSeries / Anime / Movie only. CloudStream also returns `LiveStreamLoadResponse` for Live TV and `TorrentLoadResponse` for magnet entries, and neither matched — so `load()` succeeded, the title, poster and plot rendered, and the one playable entry was silently dropped. Every Live TV plugin in the installed Phisher repo (IPTVPlayer, QuickIPTV, PublicSportsIPTV) opened to a detail page with nothing to press.

- LiveStreamLoadResponse carries a `dataUrl` exactly like a movie, so it maps to a single "Watch live" entry handed straight to loadLinks.
- TorrentLoadResponse has no dataUrl and no HTTP stream. Rather than render the same silent empty page, it now reports that the player cannot open it.
- Any other empty episode list also carries a reason naming the response class, so the next unmapped type is one log line away instead of another blank screen.

The Flutter side was discarding that reason: getEpisodes treated any non-empty map as success and fell through to a generic "no episodes", which reads identically to a title that genuinely has none. It now surfaces the host's message for all four on-device hosts.