### PR TITLE
fix(tv): put D-pad focus inside player sheets and the quality panel

### DIFF
--- a/lib/core/system/responsive.dart
+++ b/lib/core/system/responsive.dart
@@ -201,6 +201,59 @@ class _DesktopRefreshButtonState extends State<DesktopRefreshButton>
   }
 }
 
+/// Puts D-pad focus inside the sheet it wraps.
+///
+/// A modal route does not move focus into itself. On a phone that is invisible —
+/// the next interaction is a tap. On a television it is the whole bug: the sheet
+/// appears, focus is still on the control *behind* it, and the first few remote
+/// presses either do nothing or drive the player underneath. Every "the settings
+/// menu opens but the remote is dead" report traces back to this.
+///
+/// Runs after the first frame because the route's subtree — and therefore its
+/// focusable descendants — does not exist yet during build. If a descendant
+/// declared `autofocus` (the selected row, typically) it has already claimed
+/// focus by then and this is a no-op, which is exactly the desired precedence:
+/// land on the current value, not the first item.
+class _TvFocusEntry extends StatefulWidget {
+  const _TvFocusEntry({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_TvFocusEntry> createState() => _TvFocusEntryState();
+}
+
+class _TvFocusEntryState extends State<_TvFocusEntry> {
+  final FocusScopeNode _scope = FocusScopeNode(debugLabel: 'tvModal');
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (_scope.focusedChild != null) return; // an autofocus already won
+      // nextFocus() from the scope lands on its first focusable descendant.
+      _scope.nextFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _scope.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // The traversal group keeps arrow keys inside the sheet, so the D-pad
+    // cannot wander back onto the player controls behind the barrier.
+    return FocusScope(
+      node: _scope,
+      child: FocusTraversalGroup(child: widget.child),
+    );
+  }
+}
+
 Future<T?> showAdaptiveModal<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -209,7 +262,39 @@ Future<T?> showAdaptiveModal<T>({
   ShapeBorder? shape,
   bool showDragHandle = false,
   double desktopMaxWidth = 460,
+  double tvMaxWidth = 620,
 }) {
+  // Television: a centred dialog, not a bottom sheet.
+  //
+  // A bottom sheet is a thumb affordance — it hugs the edge furthest from the
+  // eye line on a 10-foot screen, and its width is set by the screen, so on a
+  // TV it renders as a short, very wide strip. The same content as a centred
+  // panel reads correctly and, more importantly, gives the remote one obvious
+  // place to be.
+  if (isTvPlatform) {
+    return showDialog<T>(
+      context: context,
+      builder: (ctx) => _TvFocusEntry(
+        child: Dialog(
+          backgroundColor: backgroundColor,
+          clipBehavior: Clip.antiAlias,
+          insetPadding: const EdgeInsets.symmetric(
+            horizontal: 48,
+            vertical: 32,
+          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: tvMaxWidth,
+              // Overscan-safe: TVs crop the outer few percent of the panel.
+              maxHeight: MediaQuery.sizeOf(ctx).height * 0.78,
+            ),
+            child: SingleChildScrollView(child: builder(ctx)),
+          ),
+        ),
+      ),
+    );
+  }
   if (isDesktopPlatform) {
     return showDialog<T>(
       context: context,

--- a/lib/features/detail/presentation/pages/player_page.controls.dart
+++ b/lib/features/detail/presentation/pages/player_page.controls.dart
@@ -170,10 +170,23 @@ extension _PlayerControls on _PlayerPageState {
     });
     _controlsAnimation.forward();
     _hideTimer?.cancel();
+    if (isTvPlatform) {
+      // Post-frame: the panel's rows do not exist yet during this build, so
+      // there is nothing to focus until it has been laid out. An `autofocus`
+      // row (the active quality/episode) claims focus first and this becomes a
+      // no-op — which is the order we want.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _panel == _SidePanel.none) return;
+        if (_tvPanelFocus.focusedChild == null) _tvPanelFocus.nextFocus();
+      });
+    }
   }
 
   void _closePanel() {
     setState(() => _panel = _SidePanel.none);
+    // Give the remote back to the player controls; otherwise focus dies with
+    // the unmounted panel and the next D-pad press has nowhere to go.
+    if (isTvPlatform) _tvRootFocus.requestFocus();
     _scheduleHide();
   }
 

--- a/lib/features/detail/presentation/pages/player_page.dart
+++ b/lib/features/detail/presentation/pages/player_page.dart
@@ -232,6 +232,18 @@ class _PlayerPageState extends State<PlayerPage>
   // node, it would no longer be in the key-event chain and the remote would go
   // dead until the next tap.
   final FocusScopeNode _tvRootFocus = FocusScopeNode(debugLabel: 'tvPlayerRoot');
+
+  /// Focus scope for the TV side panel (quality / episodes).
+  ///
+  /// The panel is drawn INSIDE the player's own focus scope, so opening it did
+  /// not move focus: the rows' `autofocus` only wins when nothing in the
+  /// enclosing scope holds focus, and the player controls always do. The panel
+  /// therefore appeared while the remote kept driving the controls behind it —
+  /// which is what "quality doesn't work on TV" actually was. Giving the panel
+  /// its own scope lets [_openPanel] hand focus over and [_closePanel] hand it
+  /// back deterministically.
+  final FocusScopeNode _tvPanelFocus =
+      FocusScopeNode(debugLabel: 'tvPlayerPanel');
   final FocusNode _tvPlayFocus = FocusNode(debugLabel: 'tvPlayerPlay');
   final FocusNode _tvSeekFocus = FocusNode(debugLabel: 'tvPlayerSeek');
 
@@ -339,6 +351,7 @@ class _PlayerPageState extends State<PlayerPage>
     _seekRippleTimer?.cancel();
     _tvSeekCommit?.cancel();
     _tvRootFocus.dispose();
+    _tvPanelFocus.dispose();
     _tvPlayFocus.dispose();
     _tvSeekFocus.dispose();
     _tvPanelScroll?.dispose();

--- a/lib/features/detail/presentation/pages/player_page.panels.dart
+++ b/lib/features/detail/presentation/pages/player_page.panels.dart
@@ -489,11 +489,17 @@ extension _PlayerPanels on _PlayerPageState {
       top: 0,
       bottom: 0,
       right: 0,
-      width: 320,
+      // Wider on TV: 320dp is a phone drawer, and at 10 feet the episode
+      // labels in it truncate to uselessness.
+      width: isTvPlatform ? 420 : 320,
       child: Material(
         color: Colors.black.withValues(alpha: 0.92),
         child: SafeArea(
-          child: Column(
+          // Its own focus scope so _openPanel can hand the remote over and
+          // _closePanel can hand it back — see [_tvPanelFocus].
+          child: FocusScope(
+            node: _tvPanelFocus,
+            child: Column(
             children: [
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
@@ -510,6 +516,7 @@ extension _PlayerPanels on _PlayerPageState {
                     const Spacer(),
                     IconButton(
                       onPressed: _closePanel,
+                      focusColor: _kTvFocusFill,
                       icon: const Icon(
                         Icons.close_rounded,
                         color: Colors.white70,
@@ -553,6 +560,7 @@ extension _PlayerPanels on _PlayerPageState {
                       ),
               ),
             ],
+            ),
           ),
         ),
       ),

--- a/lib/features/detail/presentation/pages/player_page.subtitles.dart
+++ b/lib/features/detail/presentation/pages/player_page.subtitles.dart
@@ -142,6 +142,7 @@ extension _PlayerSubtitles on _PlayerPageState {
                 ),
               const Divider(color: Colors.white12, height: 1),
               ListTile(
+                focusColor: _kTvFocusFill,
                 leading: const Icon(Icons.travel_explore_rounded,
                     color: Colors.white70, size: 20),
                 title: Text('player.search_online'.tr(),
@@ -153,6 +154,7 @@ extension _PlayerSubtitles on _PlayerPageState {
               ),
               if (_activeSubtitleIndex != -1)
               ListTile(
+                focusColor: _kTvFocusFill,
                 leading: const Icon(Icons.av_timer_rounded,
                     color: Colors.white70, size: 20),
                 title: Text('player.subtitle_sync'.tr(),
@@ -481,8 +483,13 @@ extension _PlayerSubtitles on _PlayerPageState {
       shrinkWrap: true,
       padding: EdgeInsets.zero,
       children: [
-        for (final r in results.take(60))
+        for (final (i, r) in results.take(60).indexed)
           ListTile(
+            focusColor: _kTvFocusFill,
+            // Put the remote on the first result as soon as the list renders,
+            // so "search online" ends with something selected rather than a
+            // list the D-pad has to find its way into.
+            autofocus: isTvPlatform && i == 0,
             dense: true,
             title: Text(r.fileName.isNotEmpty ? r.fileName : r.display,
                 maxLines: 2,
@@ -1041,6 +1048,7 @@ extension _PlayerSubtitles on _PlayerPageState {
                       child: InkWell(
                         onTap: () =>
                             apply(_subtitleStyle.copyWith(bold: !_subtitleStyle.bold)),
+                        focusColor: _kTvFocusFill,
                         borderRadius: BorderRadius.circular(10),
                         child: Padding(
                           padding: const EdgeInsets.symmetric(

--- a/lib/features/detail/presentation/pages/player_page.widgets.dart
+++ b/lib/features/detail/presentation/pages/player_page.widgets.dart
@@ -654,6 +654,12 @@ class _OptionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
+      // Land the remote on the value that is already active, the way the
+      // episode and quality rows in the side panel do. Without it the sheet
+      // opened with focus on the first row, so "change the subtitle track"
+      // started by moving *away* from the current one — and if nothing else
+      // claimed focus the D-pad appeared dead entirely.
+      autofocus: isTvPlatform && selected,
       focusColor: _kTvFocusFill,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),


### PR DESCRIPTION
On Android TV the subtitle, quality, speed and audio pickers opened but the remote kept driving whatever was behind them. Three separate causes, one symptom:

- `showAdaptiveModal` had a desktop branch and a phone branch, and Android TV (isDesktopPlatform is false there) fell into the phone one — a bottom sheet. On a 10-foot screen that is anchored to the edge furthest from the eye line and stretched to the full screen width. TV now gets a centred, width-capped dialog, sized to stay inside the overscan area.

- A modal route does not move focus into itself. Nothing in these sheets was focused on open, so the first remote presses went to the player underneath. Sheets opened on TV now hand focus to their first focusable after layout, and are wrapped in a traversal group so arrows cannot wander back out.

- The quality/episodes side panel had the same problem for a subtler reason: it is drawn inside the player's own focus scope, so the rows' `autofocus` could never win against the controls already holding focus. It has its own scope now; _openPanel hands the remote over and _closePanel hands it back.

Also: _OptionTile autofocuses the selected value on TV — the episode and quality rows already did this, so changing a subtitle track started by moving away from the current one. And the online-subtitle results, the sync/search rows and the bold toggle had no focus highlight at all, so even once reached there was nothing on screen saying where the remote was.

Nothing changes off TV: every branch is behind isTvPlatform, and the phone and desktop modal paths are untouched.