### PR TITLE
Sync watch history with the signed-in account

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -25,6 +25,8 @@ import 'package:soplay/features/watch_party/data/watch_party_remote_data_source.
 import 'package:soplay/features/watch_party/data/watch_party_service.dart';
 import 'package:soplay/features/download/data/download_service.dart';
 import 'package:soplay/features/history/data/history_service.dart';
+import 'package:soplay/features/history/data/history_sync_remote_data_source.dart';
+import 'package:soplay/features/history/data/history_sync_service.dart';
 import 'package:soplay/features/auth/domain/usecases/register_usecase.dart';
 import 'package:soplay/features/auth/domain/usecases/resend_otp_usecase.dart';
 import 'package:soplay/features/auth/domain/usecases/verify_otp_usecase.dart';
@@ -167,6 +169,19 @@ Future<void> configureDependencies() async {
     CfBypassInterceptor(dio: dio, service: getIt<CfBypassService>()),
   );
   getIt.registerSingleton<Dio>(dio);
+
+  // Watch history sync. Registered after Dio because it rides the authenticated
+  // client: the bearer token and its silent refresh come from the existing
+  // interceptor rather than being re-implemented here.
+  getIt.registerSingleton<HistorySyncRemoteDataSource>(
+    HistorySyncRemoteDataSource(dio: getIt<Dio>()),
+  );
+  getIt.registerSingleton<HistorySyncService>(
+    HistorySyncService(
+      remote: getIt<HistorySyncRemoteDataSource>(),
+      local: getIt<HistoryService>(),
+    ),
+  );
 
   getIt.registerSingleton<AuthRemoteDataSource>(
     AuthRemoteDataSource(dio: getIt<Dio>()),

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -6,6 +6,8 @@ import 'package:soplay/features/auth/domain/entities/auth_token.dart';
 import 'package:soplay/features/auth/domain/entities/user_entity.dart';
 import '../../domain/repositories/auth_repository.dart';
 import '../datasources/auth_remote_data_source.dart';
+import 'package:soplay/core/di/injection.dart';
+import 'package:soplay/features/history/data/history_sync_service.dart';
 
 class AuthRepositoryImpl implements AuthRepository {
   final AuthRemoteDataSource _remoteDataSource;
@@ -107,10 +109,22 @@ class AuthRepositoryImpl implements AuthRepository {
     try {
       await _remoteDataSource.logout();
     } on DioException {
-      await _hiveService.clearAuth();
+      await _clearAccountScopedData();
       return;
     }
+    await _clearAccountScopedData();
+  }
+
+  /// Tokens are not the only account-scoped state on the device.
+  ///
+  /// The watch-history sync cursor points at one account's rows; left behind,
+  /// the next sign-in resumes from a stranger's position and uploads this
+  /// person's viewing into their history.
+  Future<void> _clearAccountScopedData() async {
     await _hiveService.clearAuth();
+    if (getIt.isRegistered<HistorySyncService>()) {
+      await getIt<HistorySyncService>().clear();
+    }
   }
 
   String _messageFrom(DioException e) {

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -14,6 +14,8 @@ import 'package:soplay/features/my_list/domain/usecases/sync_favorites_usecase.d
 import 'package:soplay/features/notifications/data/services/notification_service.dart';
 
 import 'auth_event.dart';
+import 'package:soplay/core/di/injection.dart';
+import 'package:soplay/features/history/data/history_sync_service.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final LoginUseCase loginUseCase;
@@ -78,6 +80,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     );
 
     unawaited(syncFavorites());
+    unawaited(_syncHistory());
     unawaited(notificationService.setup());
     add(const AuthProfileRefreshRequested());
   }
@@ -92,6 +95,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       case Success(:final value):
         emit(AuthLoaded(token: value));
         unawaited(syncFavorites());
+        unawaited(_syncHistory());
         unawaited(notificationService.setup());
       case Failure(:final error):
         emit(AuthError(message: _friendlyError(error)));
@@ -137,6 +141,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       case Success(:final value):
         emit(AuthLoaded(token: value));
         unawaited(syncFavorites());
+        unawaited(_syncHistory());
         unawaited(notificationService.setup());
       case Failure(:final error):
         final msg = _friendlyError(error);
@@ -247,6 +252,17 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           );
         }
     }
+  }
+
+  /// Pull the account's watch history on sign-in.
+  ///
+  /// Alongside syncFavorites rather than inside it: favorites are a curated
+  /// list the user owns, history is written by the player, and the two fail
+  /// independently. Registration is checked because the bloc is constructed in
+  /// tests where the sync service is not wired.
+  Future<void> _syncHistory() async {
+    if (!getIt.isRegistered<HistorySyncService>()) return;
+    await getIt<HistorySyncService>().sync();
   }
 
   String _friendlyError(Object error) {

--- a/lib/features/detail/presentation/pages/player_page.dart
+++ b/lib/features/detail/presentation/pages/player_page.dart
@@ -52,6 +52,7 @@ import 'package:soplay/features/watch_party/presentation/widgets/party_reactions
 import 'package:url_launcher/url_launcher.dart';
 import 'package:soplay/core/player/media_controller.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:soplay/features/history/data/history_sync_service.dart';
 
 part 'player_page.models.dart';
 part 'player_page.widgets.dart';
@@ -343,6 +344,10 @@ class _PlayerPageState extends State<PlayerPage>
   @override
   void dispose() {
     _saveHistory();
+    // Push the position the viewer just stopped at, so another device can pick
+    // it up. Without this the progress only leaves the phone the next time the
+    // History screen happens to be opened.
+    getIt<HistorySyncService>().sync();
     _partyDispose();
     WidgetsBinding.instance.removeObserver(this);
     _pipChannel.setMethodCallHandler(null);

--- a/lib/features/history/data/history_sync_remote_data_source.dart
+++ b/lib/features/history/data/history_sync_remote_data_source.dart
@@ -1,0 +1,142 @@
+import 'package:dio/dio.dart';
+
+/// One history row on the wire.
+///
+/// The field names are the server's contract and are shared verbatim with the
+/// Android TV client. Renaming one here does not break a build — it silently
+/// splits the same episode into two rows that never reconcile, so treat this
+/// shape as fixed unless the server and the TV move with it.
+class HistorySyncItem {
+  const HistorySyncItem({
+    required this.provider,
+    this.key,
+    this.contentUrl,
+    this.contentId,
+    this.title,
+    this.thumbnail,
+    this.isSerial = false,
+    this.episodeIndex,
+    this.episodeNumber,
+    this.episodeLabel,
+    this.positionMs = 0,
+    this.durationMs = 0,
+    this.extra,
+    this.watchedAt,
+    this.deletedAt,
+  });
+
+  final String provider;
+
+  /// Server-assigned identity. Echoed back as-is; the client never invents one
+  /// except for a tombstone, which has no row left to read it from.
+  final String? key;
+  final String? contentUrl;
+  final String? contentId;
+  final String? title;
+  final String? thumbnail;
+  final bool isSerial;
+  final int? episodeIndex;
+  final int? episodeNumber;
+  final String? episodeLabel;
+  final int positionMs;
+  final int durationMs;
+
+  /// Whatever the originating platform stores beyond the shared shape. The TV
+  /// puts its whole Room row here; this client passes it through untouched so a
+  /// round trip through the phone does not strip a TV row of what makes it
+  /// playable.
+  final Map<String, dynamic>? extra;
+
+  final String? watchedAt;
+  final String? deletedAt;
+
+  bool get isDeleted => deletedAt != null;
+
+  Map<String, dynamic> toJson() => {
+    'provider': provider,
+    if (key != null) 'key': key,
+    if (contentUrl != null) 'contentUrl': contentUrl,
+    if (contentId != null) 'contentId': contentId,
+    if (title != null) 'title': title,
+    if (thumbnail != null) 'thumbnail': thumbnail,
+    'isSerial': isSerial,
+    if (episodeIndex != null) 'episodeIndex': episodeIndex,
+    if (episodeNumber != null) 'episodeNumber': episodeNumber,
+    if (episodeLabel != null) 'episodeLabel': episodeLabel,
+    'positionMs': positionMs,
+    'durationMs': durationMs,
+    if (extra != null) 'extra': extra,
+    if (watchedAt != null) 'watchedAt': watchedAt,
+    if (deletedAt != null) 'deletedAt': deletedAt,
+  };
+
+  factory HistorySyncItem.fromJson(Map<String, dynamic> json) =>
+      HistorySyncItem(
+        provider: json['provider'] as String? ?? '',
+        key: json['key'] as String?,
+        contentUrl: json['contentUrl'] as String?,
+        contentId: json['contentId'] as String?,
+        title: json['title'] as String?,
+        thumbnail: json['thumbnail'] as String?,
+        isSerial: json['isSerial'] as bool? ?? false,
+        episodeIndex: (json['episodeIndex'] as num?)?.toInt(),
+        episodeNumber: (json['episodeNumber'] as num?)?.toInt(),
+        episodeLabel: json['episodeLabel'] as String?,
+        positionMs: (json['positionMs'] as num?)?.toInt() ?? 0,
+        durationMs: (json['durationMs'] as num?)?.toInt() ?? 0,
+        extra: (json['extra'] as Map?)?.cast<String, dynamic>(),
+        watchedAt: json['watchedAt'] as String?,
+        deletedAt: json['deletedAt'] as String?,
+      );
+}
+
+class HistorySyncResult {
+  const HistorySyncResult({required this.items, this.serverTime});
+
+  final List<HistorySyncItem> items;
+
+  /// The server's clock. Becomes the next request's `since`, so a phone with a
+  /// wrong clock still pages correctly.
+  final String? serverTime;
+}
+
+/// Transport for `/auth/history/sync`.
+///
+/// Uses the app's authenticated [Dio], so the bearer token and its silent
+/// refresh come from the existing interceptor rather than being re-implemented.
+class HistorySyncRemoteDataSource {
+  const HistorySyncRemoteDataSource({required this.dio});
+
+  final Dio dio;
+
+  /// Pushes [items] and returns everything changed elsewhere since [since].
+  ///
+  /// An empty [items] is an ordinary pull, not a special case: a phone with no
+  /// local changes still wants the TV's progress.
+  Future<HistorySyncResult> sync({
+    required List<HistorySyncItem> items,
+    String? since,
+  }) async {
+    final response = await dio.post(
+      '/auth/history/sync',
+      data: {
+        'items': items.map((e) => e.toJson()).toList(growable: false),
+        'since': ?since,
+      },
+    );
+
+    final data = response.data;
+    final raw = data is Map ? data['items'] : null;
+    return HistorySyncResult(
+      items: raw is List
+          ? raw
+                .whereType<Map>()
+                .map(
+                  (e) => HistorySyncItem.fromJson(e.cast<String, dynamic>()),
+                )
+                .toList(growable: false)
+          : const [],
+      serverTime: data is Map ? data['serverTime'] as String? : null,
+    );
+  }
+}

--- a/lib/features/history/data/history_sync_service.dart
+++ b/lib/features/history/data/history_sync_service.dart
@@ -1,0 +1,232 @@
+import 'dart:convert';
+
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:soplay/core/constants/app_constants.dart';
+import 'package:soplay/features/history/data/history_service.dart';
+import 'package:soplay/features/history/data/history_sync_remote_data_source.dart';
+import 'package:soplay/features/history/domain/entities/history_item.dart';
+
+/// Keeps this phone's watch history in step with the signed-in account.
+///
+/// WHAT ACTUALLY SYNCS, and why it is not simply "everything":
+///
+/// A TV row is a Room record keyed by a provider `session` — a handle for one
+/// episode stream on that box. Its `contentUrl` is a stream address, not
+/// something this app can open. Materialising it here would fill History with
+/// rows that lead nowhere.
+///
+/// So the split is deliberate and symmetric with the TV's:
+///   * phone → phone  full rows.
+///   * phone ↔ TV     resume position on content both can name. If the TV got
+///                    further into an episode this phone already knows, the
+///                    phone picks up there. A TV-only title stays on the server
+///                    for the TV and is not faked into this list.
+///
+/// Deletes travel as tombstones. Hive deletes leave nothing behind to upload,
+/// so without recording one the next sync would see the server's copy as new
+/// and put the row straight back.
+class HistorySyncService {
+  HistorySyncService({
+    required HistorySyncRemoteDataSource remote,
+    required HistoryService local,
+  }) : _remote = remote,
+       _local = local;
+
+  final HistorySyncRemoteDataSource _remote;
+  final HistoryService _local;
+
+  Box get _state => Hive.box(AppConstants.settingsBox);
+
+  static const String _cursorKey = 'history_sync_cursor';
+  static const String _pushedAtKey = 'history_sync_pushed_at';
+  static const String _tombstonesKey = 'history_sync_tombstones';
+
+  bool _running = false;
+
+  /// True once this account has ever synced here.
+  bool get hasSynced => _state.get(_cursorKey) != null;
+
+  /// Canonical identity, mirroring the server's `buildHistoryKey` EXACTLY.
+  ///
+  /// Drifting from it splits one episode into two rows that never reconcile,
+  /// so this and the server's copy must change together.
+  static String? keyOf(HistoryItem item) {
+    final base = item.contentUrl.trim();
+    if (base.isEmpty) return null;
+    final head = '${item.provider.trim()}|$base';
+    if (!item.isSerial) return head;
+    final episode = item.episodeNumber ?? item.episodeIndex;
+    return episode == null ? head : '$head|e$episode';
+  }
+
+  /// Push local changes, pull everyone else's, write the result to Hive.
+  ///
+  /// Guarded by [_running] because playback-end and screen-open can both land
+  /// here at once; two interleaved runs would push the same rows twice and race
+  /// over the cursor.
+  ///
+  /// Returns false when nothing could be done — signed out, or offline. That is
+  /// "try again later", never an error worth showing.
+  Future<bool> sync() async {
+    if (_running) return false;
+    _running = true;
+    try {
+      final since = _state.get(_cursorKey) as String?;
+      final pushedAt = (_state.get(_pushedAtKey) as num?)?.toInt() ?? 0;
+      final tombstones = _readTombstones();
+
+      final outgoing = <HistorySyncItem>[
+        // Only rows touched since the last successful push. Uploading
+        // everything each time would rewrite the whole server list and wake
+        // every other device for nothing.
+        for (final item in _local.getAll())
+          if (item.watchedAt > pushedAt) _toSyncItem(item),
+        for (final entry in tombstones.entries)
+          HistorySyncItem(
+            provider: '',
+            key: entry.key,
+            deletedAt: entry.value,
+            watchedAt: entry.value,
+          ),
+      ];
+
+      final result = await _remote.sync(items: outgoing, since: since);
+      await _applyRemote(result.items);
+
+      await _state.put(_cursorKey, result.serverTime ?? since);
+      // Stamped from the rows just sent, not from "now": a row written while
+      // the request was in flight must still be picked up next time.
+      final highest = outgoing
+          .map((e) => DateTime.tryParse(e.watchedAt ?? '')?.millisecondsSinceEpoch ?? 0)
+          .fold<int>(pushedAt, (a, b) => b > a ? b : a);
+      await _state.put(_pushedAtKey, highest);
+      await _state.delete(_tombstonesKey);
+      return true;
+    } catch (_) {
+      // Offline or signed out. Tombstones are deliberately kept: they must
+      // survive until a sync actually accepts them.
+      return false;
+    } finally {
+      _running = false;
+    }
+  }
+
+  /// Records a delete so it can travel. Call BEFORE removing the local row.
+  Future<void> rememberDeleted(HistoryItem item) async {
+    final key = keyOf(item);
+    if (key == null) return;
+    final all = _readTombstones()
+      ..[key] = DateTime.now().toUtc().toIso8601String();
+    await _state.put(_tombstonesKey, jsonEncode(all));
+  }
+
+  /// Records a full clear. Call BEFORE clearing local history.
+  Future<void> rememberClearedAll() async {
+    final now = DateTime.now().toUtc().toIso8601String();
+    final all = _readTombstones();
+    for (final item in _local.getAll()) {
+      final key = keyOf(item);
+      if (key != null) all[key] = now;
+    }
+    if (all.isEmpty) return;
+    await _state.put(_tombstonesKey, jsonEncode(all));
+  }
+
+  /// Sign-out must not leave one account's cursor pointing at another's history.
+  Future<void> clear() async {
+    await _state.delete(_cursorKey);
+    await _state.delete(_pushedAtKey);
+    await _state.delete(_tombstonesKey);
+  }
+
+  // ─── applying the server's answer ──────────────────────────────────────────
+
+  Future<void> _applyRemote(List<HistorySyncItem> items) async {
+    if (items.isEmpty) return;
+    final byKey = {
+      for (final item in _local.getAll())
+        if (keyOf(item) != null) keyOf(item)!: item,
+    };
+
+    for (final remote in items) {
+      final key = remote.key;
+      if (key == null) continue;
+      final local = byKey[key];
+
+      if (remote.isDeleted) {
+        if (local != null) await _local.remove(local.storageKey);
+        continue;
+      }
+
+      final watchedAt =
+          DateTime.tryParse(remote.watchedAt ?? '')?.millisecondsSinceEpoch ?? 0;
+
+      if (local != null) {
+        // A row this phone already has: take the newer position only.
+        if (watchedAt > local.watchedAt) {
+          await _local.save(
+            local.copyWith(
+              positionMs: remote.positionMs,
+              durationMs: remote.durationMs > 0
+                  ? remote.durationMs
+                  : local.durationMs,
+              watchedAt: watchedAt,
+            ),
+          );
+        }
+        continue;
+      }
+
+      // No local row. Only a phone-origin row can be rebuilt here — a TV row's
+      // contentUrl is a stream address this app cannot open, and a History
+      // entry that leads nowhere is worse than a missing one.
+      final contentUrl = remote.contentUrl;
+      if (remote.extra != null || contentUrl == null || contentUrl.isEmpty) {
+        continue;
+      }
+      await _local.save(
+        HistoryItem(
+          contentUrl: contentUrl,
+          provider: remote.provider,
+          title: remote.title ?? '',
+          thumbnail: remote.thumbnail,
+          isSerial: remote.isSerial,
+          episodeIndex: remote.episodeIndex,
+          episodeNumber: remote.episodeNumber,
+          episodeLabel: remote.episodeLabel,
+          positionMs: remote.positionMs,
+          durationMs: remote.durationMs,
+          watchedAt: watchedAt == 0
+              ? DateTime.now().millisecondsSinceEpoch
+              : watchedAt,
+        ),
+      );
+    }
+  }
+
+  HistorySyncItem _toSyncItem(HistoryItem item) => HistorySyncItem(
+    provider: item.provider,
+    contentUrl: item.contentUrl,
+    title: item.title,
+    thumbnail: item.thumbnail,
+    isSerial: item.isSerial,
+    episodeIndex: item.episodeIndex,
+    episodeNumber: item.episodeNumber,
+    episodeLabel: item.episodeLabel,
+    positionMs: item.positionMs,
+    durationMs: item.durationMs,
+    watchedAt: DateTime.fromMillisecondsSinceEpoch(
+      item.watchedAt,
+    ).toUtc().toIso8601String(),
+  );
+
+  Map<String, String> _readTombstones() {
+    final raw = _state.get(_tombstonesKey);
+    if (raw is! String) return <String, String>{};
+    try {
+      return (jsonDecode(raw) as Map).cast<String, String>();
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+}

--- a/lib/features/history/presentation/pages/history_page.dart
+++ b/lib/features/history/presentation/pages/history_page.dart
@@ -6,6 +6,7 @@ import 'package:soplay/core/system/platform_utils.dart';
 import 'package:soplay/core/theme/app_colors.dart';
 import 'package:soplay/features/detail/domain/entities/detail_args.dart';
 import 'package:soplay/features/history/data/history_service.dart';
+import 'package:soplay/features/history/data/history_sync_service.dart';
 import 'package:soplay/features/history/domain/entities/history_item.dart';
 import 'package:soplay/features/home/presentation/widgets/home_shared_widgets.dart';
 
@@ -18,13 +19,18 @@ class HistoryPage extends StatefulWidget {
 
 class _HistoryPageState extends State<HistoryPage> {
   final HistoryService _historyService = getIt<HistoryService>();
+  final HistorySyncService _syncService = getIt<HistorySyncService>();
   List<HistoryItem> _items = const [];
 
   @override
   void initState() {
     super.initState();
     _historyService.revision.addListener(_reload);
+    // Cached first, then synced. Waiting on the network to draw a list that is
+    // already on disk would leave the screen empty on a slow link; the reload
+    // is driven by the service's own revision notifier once rows land.
     _reload();
+    _syncService.sync();
   }
 
   @override
@@ -67,7 +73,13 @@ class _HistoryPageState extends State<HistoryPage> {
           TextButton(
             onPressed: () {
               Navigator.of(ctx).pop();
-              _historyService.clearAll();
+              // Tombstone first, then clear: once the rows are gone there is
+              // nothing left to describe the delete, and the next sync would
+              // download the whole list straight back.
+              _syncService
+                  .rememberClearedAll()
+                  .then((_) => _historyService.clearAll())
+                  .then((_) => _syncService.sync());
             },
             child: Text(
               'history.clear'.tr(),
@@ -88,7 +100,10 @@ class _HistoryPageState extends State<HistoryPage> {
         _items = _items.where((e) => e.storageKey != item.storageKey).toList();
       });
     }
-    _historyService.remove(item.storageKey);
+    _syncService
+        .rememberDeleted(item)
+        .then((_) => _historyService.remove(item.storageKey))
+        .then((_) => _syncService.sync());
   }
 
   @override


### PR DESCRIPTION
Watching half an episode here and finishing it on the TV meant finding the place again by hand. History never left the phone.

Depends on **sozo-backend#7**, which adds `POST /auth/history/sync`. Pairs with **sozo-tv#9**.

## What syncs — deliberately not "everything"

A TV row is keyed by a provider `session`, and its `contentUrl` is a stream address this app cannot open. Materialising it would fill History with rows that lead nowhere.

| Direction | What travels |
|---|---|
| phone → phone | whole rows |
| phone ↔ TV | the resume position, on content both can already name |

The TV client applies the mirror-image rule, so neither side invents a row it cannot open.

## New

- `HistorySyncRemoteDataSource` — transport for `/auth/history/sync`, on the app's authenticated Dio, so the bearer token and its silent refresh come from the existing interceptor
- `HistorySyncService` — cursor, tombstones, and the Hive merge

## Decisions worth reviewing

**Deletes are recorded before the Hive row goes.** A delete leaves nothing behind to upload, so without a tombstone the next sync sees the server's copy as new and puts the row straight back.

**`keyOf` mirrors the server's `buildHistoryKey` exactly.** Drifting from it does not fail loudly; it splits one episode into two rows that never reconcile. The two must change together.

**Syncs fire where progress changes** — leaving the player, opening History, clearing it, signing in. Without the player hook, progress only left the phone when someone happened to open the History screen.

**Sign-out clears the cursor along with the tokens.** It points at one account's rows; left behind, the next sign-in resumes from a stranger's position and uploads this person's viewing into their history.

## Known limitation

The TV stores `epIndex`; this app stores `episodeNumber`. Keys line up when the numbering agrees, which is reliable for backend-served content (both apps read the same API) but not guaranteed for extension sources.

## Testing

`flutter analyze` clean. Not yet exercised against a live account with two real devices — that pass is still owed:

1. Watch half an episode here, leave the player
2. Open History on the TV — it should resume from this position
3. Clear history on the TV — this list should empty too