### PR TITLE
ci: unblock the release push, and say which version it ships

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           # The tag push below needs real history, not a shallow clone.
           fetch-depth: 0
+          # The default GITHUB_TOKEN is not an admin, so the version bump is
+          # rejected by the branch protection on the default branch. A
+          # RELEASE_PAT that belongs to somebody who can push is what gets it in.
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Resolve version
         id: resolve
@@ -187,7 +191,14 @@ jobs:
           # Pushed with GITHUB_TOKEN, which deliberately does NOT re-trigger
           # workflows. Without that guarantee this tag would start a second run
           # of this same workflow and ship the release twice.
-          git push origin HEAD:"${GITHUB_REF_NAME}"
+          #
+          # A RELEASE_PAT does re-trigger, so the tag is pushed only after the
+          # branch push succeeds — a tag with no bump behind it is worse than
+          # no tag.
+          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            echo "::error title=Push rejected::The default branch is protected and this run is not an admin. Add a RELEASE_PAT secret (a fine-grained PAT with Contents: read and write) so the version bump can land. Nothing was tagged."
+            exit 1
+          fi
           git push origin "${TAG}"
 
       - name: Record the commit every build job will use


### PR DESCRIPTION
Release run #19 failed at the version bump:

```
remote: Permission to professorDeveloper/sozo.git denied to github-actions[bot].
fatal: unable to access '.../sozo/': The requested URL returned error: 403
```

The branch protection that stops everyone else pushing to the default branch stops the bot too. The TV repo already carries this fix; mobile did not.

- Checkout takes `RELEASE_PAT` when one exists, falling back to the default token.
- The branch push is now checked **before** the tag is pushed. A tag with no version bump behind it is worse than no tag, and the previous version pushed both blind.
- The failure names the cause and the fix rather than ending in a bare 403.

### This alone does not make the run pass
There is **no `RELEASE_PAT` secret in this repo** — I checked. Without it the fallback is the same token that was just rejected.

Create it as a fine-grained PAT with **Contents: read and write** on this repo, then add it under Settings → Secrets and variables → Actions as `RELEASE_PAT`.

One consequence worth knowing: `GITHUB_TOKEN` deliberately does not re-trigger workflows, but a PAT does. That is why the tag is pushed only after the branch push succeeds — otherwise a re-triggered run could ship the release twice.