### PR TITLE
ci: say which version a run is shipping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release → Telegram
+run-name: >-
+  Release ${{ inputs.version != '' && inputs.version || inputs.bump || github.ref_name }}
 
 # Builds ALL FOUR platforms (Android / Windows / Linux / macOS) when you cut a
 # version, and hands them off. It NEVER touches GitHub Releases at all — you cut
@@ -98,6 +100,8 @@ jobs:
             *) echo "::error title=Malformed version::pubspec.yaml has 'version: ${CURRENT}' with no +buildNumber. Android needs one."; exit 1 ;;
           esac
 
+          echo "::notice title=Current version::${CURRENT}"
+
           NAME="${CURRENT%%+*}"
           BUILD="${CURRENT##*+}"
           case "${BUILD}" in
@@ -146,7 +150,11 @@ jobs:
             echo "| was | \`${CURRENT}\` |"
             echo "| now | \`${NEW_NAME}+${NEW_BUILD}\` |"
             echo "| tag | \`v${NEW_NAME}\` |"
+            echo ""
+            echo "Latest released version is now **${NEW_NAME}+${NEW_BUILD}**."
           } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::notice title=Releasing::${NEW_NAME}+${NEW_BUILD} (tag v${NEW_NAME})"
 
       - name: Commit and tag
         if: steps.resolve.outputs.bumped == 'yes'


### PR DESCRIPTION
Follows #14, which unblocked the push. This is the half that makes a run legible.

Every run in the Actions list reads `Release → Telegram`, so telling which one shipped what means opening it and scrolling.

- **Run name** now carries the requested bump, or the exact version when one was typed.
- The **current** version is annotated before anything changes, and the **resolved** one after.

Annotations sit at the top of the run page. The job summary already had a was/now table, but it only appears once the bump has already happened — and choosing between a patch and a minor needs the number you are raising *from*.

No behaviour change: nothing about what gets built, tagged or sent moves.

The same change is in **sozo-tv#19**, where it also annotates the `versionCode` — that is the value you publish on the admin panel under **androidtv** for the in-app updater.