### PR TITLE
Make the extensions work, search every source, and tidy the interface

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -98,7 +98,11 @@
     "view_all": "View all",
     "remove_from_continue": "Remove from continue watching",
     "ep_number": "EP {}",
-    "untitled": "Untitled"
+    "untitled": "Untitled",
+    "empty_title": "Nothing here yet",
+    "empty_subtitle": "Pick another source, or pull to refresh.",
+    "list_empty_title": "This list is empty",
+    "list_empty_subtitle": "Nothing to show for this section right now."
   },
   "player": {
     "play": "Play",
@@ -300,7 +304,11 @@
     "volume_gesture_desc": "Swipe up and down on the right side",
     "seconds_short": "{}s",
     "subtitle_style_note": "These apply to every video. Subtitle timing stays per episode and is set inside the player.",
-    "searching_all_sources": "searching all sources"
+    "searching_all_sources": "searching all sources",
+    "section_connections": "CONNECTIONS",
+    "section_extensions": "SOURCES",
+    "section_settings": "SETTINGS",
+    "remove_favorite": "Remove from favourites"
   },
   "search": {
     "title": "Search",
@@ -352,7 +360,26 @@
     "filter_providers": "Filter providers…",
     "selected_n": "{} selected",
     "apply_n": "Apply ({})",
-    "many_sources_warning": "Searching {} sources may be slow. The app stays responsive, but fewer is snappier."
+    "many_sources_warning": "Searching {} sources may be slow. The app stays responsive, but fewer is snappier.",
+    "all_sources_n": "All sources ({})",
+    "more_sources": "More…",
+    "select_all_sources": "Select all",
+    "search_all_sources": "Search all sources",
+    "apply_all": "Search all sources",
+    "selected_n_of_m": "{} of {} sources",
+    "loading_sources": "Loading your sources…",
+    "no_sources_available": "No sources available. Add or enable a source to search.",
+    "min_query_n": "Type at least {} characters.",
+    "retry_failed": "Retry failed",
+    "status_searching": "Searching…",
+    "status_searching_n": "{} searching",
+    "status_with_results_n": "{} with results",
+    "status_no_match_n": "{} no match",
+    "status_timed_out_n": "{} timed out",
+    "status_failed_n": "{} failed",
+    "all_sources_failed": "All {} sources failed to answer. This is not an empty result — try again.",
+    "no_results_with_failures": "No matches from the sources that answered ({}). {} could not be reached.",
+    "all_sources_failed_one": "The source you searched failed to answer. This is not an empty result — try again."
   },
   "movie": {
     "rating": "Rating",
@@ -729,7 +756,12 @@
     "follow_series": "Follow series",
     "find_other_sources": "Find other sources",
     "anilist_track": "Track on AniList",
-    "anilist_tracked": "Tracked on AniList"
+    "anilist_tracked": "Tracked on AniList",
+    "following_on": "Following",
+    "following_off": "Not following",
+    "no_screenshots": "No screenshots",
+    "show_more": "Show more",
+    "show_less": "Show less"
   },
   "shorts": {
     "refresh": "Refresh",
@@ -1006,7 +1038,11 @@
     "episodes_count": "{count} eps",
     "reminder_body": "Episode {episode} airs in 10 minutes",
     "reminders_on": "Remind me before episodes air",
-    "reminders_off": "Episode reminders are off"
+    "reminders_off": "Episode reminders are off",
+    "connect_first": "Connect AniList first",
+    "save_failed": "Couldn't save to AniList",
+    "search_in_source": "SEARCH IN ONE SOURCE",
+    "no_sources": "No sources installed yet"
   },
   "tracker": {
     "title": "Tracking",
@@ -1051,5 +1087,17 @@
     "empty": "No channels yet.",
     "load_failed": "Couldn't load the channels.",
     "retry": "Try again"
+  },
+  "time": {
+    "now": "just now",
+    "minutes": "{} min ago",
+    "hours": "{} h ago",
+    "days": "{} d ago"
+  },
+  "user_lists": {
+    "title": "My Lists",
+    "remove": "Remove",
+    "empty_title": "Nothing saved yet",
+    "empty_subtitle": "Titles you save show up here."
   }
 }

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -98,7 +98,11 @@
     "view_all": "Смотреть все",
     "remove_from_continue": "Убрать из «Продолжить просмотр»",
     "ep_number": "EP {}",
-    "untitled": "Без названия"
+    "untitled": "Без названия",
+    "empty_title": "Здесь пока пусто",
+    "empty_subtitle": "Выберите другой источник или потяните для обновления.",
+    "list_empty_title": "Список пуст",
+    "list_empty_subtitle": "Для этого раздела сейчас ничего нет."
   },
   "player": {
     "play": "Воспроизвести",
@@ -300,7 +304,11 @@
     "volume_gesture_desc": "Свайп вверх и вниз справа",
     "seconds_short": "{} с",
     "subtitle_style_note": "Действуют для всех видео. Тайминг субтитров задаётся отдельно для каждой серии в плеере.",
-    "searching_all_sources": "поиск по всем источникам"
+    "searching_all_sources": "поиск по всем источникам",
+    "section_connections": "ПОДКЛЮЧЕНИЯ",
+    "section_extensions": "ИСТОЧНИКИ",
+    "section_settings": "НАСТРОЙКИ",
+    "remove_favorite": "Убрать из избранного"
   },
   "search": {
     "title": "Поиск",
@@ -352,7 +360,26 @@
     "filter_providers": "Фильтр провайдеров…",
     "selected_n": "Выбрано: {}",
     "apply_n": "Применить ({})",
-    "many_sources_warning": "Поиск по {} источникам может быть медленным. Приложение не зависнет, но с меньшим числом источников быстрее."
+    "many_sources_warning": "Поиск по {} источникам может быть медленным. Приложение не зависнет, но с меньшим числом источников быстрее.",
+    "all_sources_n": "Все источники ({})",
+    "more_sources": "Ещё…",
+    "select_all_sources": "Выбрать все",
+    "search_all_sources": "Искать во всех источниках",
+    "apply_all": "Искать во всех источниках",
+    "selected_n_of_m": "{} из {} источников",
+    "loading_sources": "Загружаем источники…",
+    "no_sources_available": "Нет доступных источников. Добавьте или включите источник.",
+    "min_query_n": "Введите минимум {} символа.",
+    "retry_failed": "Повторить неудачные",
+    "status_searching": "Идёт поиск…",
+    "status_searching_n": "{} в процессе",
+    "status_with_results_n": "{} с результатами",
+    "status_no_match_n": "{} без совпадений",
+    "status_timed_out_n": "{} по таймауту",
+    "status_failed_n": "{} с ошибкой",
+    "all_sources_failed": "Все {} источников не ответили. Это не пустой результат — попробуйте снова.",
+    "no_results_with_failures": "Среди ответивших источников ({}) совпадений нет. Недоступны: {}.",
+    "all_sources_failed_one": "Источник не ответил. Это не пустой результат — попробуйте снова."
   },
   "movie": {
     "rating": "Рейтинг",
@@ -729,7 +756,12 @@
     "follow_series": "Следить за сериалом",
     "find_other_sources": "Найти в других источниках",
     "anilist_track": "Отслеживать в AniList",
-    "anilist_tracked": "Отслеживается в AniList"
+    "anilist_tracked": "Отслеживается в AniList",
+    "following_on": "Отслеживается",
+    "following_off": "Не отслеживается",
+    "no_screenshots": "Нет кадров",
+    "show_more": "Показать больше",
+    "show_less": "Свернуть"
   },
   "shorts": {
     "refresh": "Обновить",
@@ -1006,7 +1038,11 @@
     "episodes_count": "{count} эп.",
     "reminder_body": "Эпизод {episode} выйдет через 10 минут",
     "reminders_on": "Напоминать перед выходом эпизодов",
-    "reminders_off": "Напоминания выключены"
+    "reminders_off": "Напоминания выключены",
+    "connect_first": "Сначала подключите AniList",
+    "save_failed": "Не удалось сохранить в AniList",
+    "search_in_source": "ИСКАТЬ В ОДНОМ ИСТОЧНИКЕ",
+    "no_sources": "Источники не установлены"
   },
   "tracker": {
     "title": "Tracking",
@@ -1051,5 +1087,17 @@
     "empty": "Каналов пока нет.",
     "load_failed": "Не удалось загрузить каналы.",
     "retry": "Повторить"
+  },
+  "time": {
+    "now": "только что",
+    "minutes": "{} мин назад",
+    "hours": "{} ч назад",
+    "days": "{} дн назад"
+  },
+  "user_lists": {
+    "title": "Мои списки",
+    "remove": "Удалить",
+    "empty_title": "Пока ничего нет",
+    "empty_subtitle": "Сохранённое появится здесь."
   }
 }

--- a/assets/translations/uz.json
+++ b/assets/translations/uz.json
@@ -98,7 +98,11 @@
     "view_all": "Barchasini ko'rish",
     "remove_from_continue": "Ko'rishni davom ettirishdan olib tashlash",
     "ep_number": "EP {}",
-    "untitled": "Nomsiz"
+    "untitled": "Nomsiz",
+    "empty_title": "Bu yerda hozircha bo‘sh",
+    "empty_subtitle": "Boshqa manba tanlang yoki yangilash uchun torting.",
+    "list_empty_title": "Bu ro‘yxat bo‘sh",
+    "list_empty_subtitle": "Bu bo‘lim uchun hozircha hech narsa yo‘q."
   },
   "player": {
     "play": "O'ynash",
@@ -300,7 +304,11 @@
     "volume_gesture_desc": "O‘ng tomonda yuqoriga-pastga surish",
     "seconds_short": "{} s",
     "subtitle_style_note": "Bular barcha videolarga tegishli. Subtitr vaqti esa har bir qism uchun alohida va pleyer ichida sozlanadi.",
-    "searching_all_sources": "barcha manbalar bo‘yicha qidirilmoqda"
+    "searching_all_sources": "barcha manbalar bo‘yicha qidirilmoqda",
+    "section_connections": "ULANISHLAR",
+    "section_extensions": "MANBALAR",
+    "section_settings": "SOZLAMALAR",
+    "remove_favorite": "Sevimlilardan olib tashlash"
   },
   "search": {
     "title": "Qidirish",
@@ -352,7 +360,26 @@
     "filter_providers": "Provayderlarni filtrlash…",
     "selected_n": "{} ta tanlandi",
     "apply_n": "Qo'llash ({})",
-    "many_sources_warning": "{} ta manbada qidiruv sekin bo'lishi mumkin. Ilova qotmaydi, lekin manbalar kamroq bo'lsa tezroq."
+    "many_sources_warning": "{} ta manbada qidiruv sekin bo'lishi mumkin. Ilova qotmaydi, lekin manbalar kamroq bo'lsa tezroq.",
+    "all_sources_n": "Barcha manbalar ({})",
+    "more_sources": "Yana…",
+    "select_all_sources": "Barchasini tanlash",
+    "search_all_sources": "Barcha manbalarda qidirish",
+    "apply_all": "Barcha manbalarda qidirish",
+    "selected_n_of_m": "{} / {} manba",
+    "loading_sources": "Manbalar yuklanmoqda…",
+    "no_sources_available": "Mavjud manba yo‘q. Manba qo‘shing yoki yoqing.",
+    "min_query_n": "Kamida {} ta belgi kiriting.",
+    "retry_failed": "Xatolarni qayta urinish",
+    "status_searching": "Qidirilmoqda…",
+    "status_searching_n": "{} qidirilmoqda",
+    "status_with_results_n": "{} natijali",
+    "status_no_match_n": "{} mos kelmadi",
+    "status_timed_out_n": "{} vaqti tugadi",
+    "status_failed_n": "{} xato",
+    "all_sources_failed": "Barcha {} manba javob bermadi. Bu bo‘sh natija emas — qayta urinib ko‘ring.",
+    "no_results_with_failures": "Javob bergan manbalarda ({}) moslik yo‘q. Ulanib bo‘lmadi: {}.",
+    "all_sources_failed_one": "Manba javob bermadi. Bu bo‘sh natija emas — qayta urinib ko‘ring."
   },
   "movie": {
     "rating": "Reyting",
@@ -729,7 +756,12 @@
     "follow_series": "Seriyani kuzatish",
     "find_other_sources": "Boshqa manbalardan izlash",
     "anilist_track": "AniList'da kuzatish",
-    "anilist_tracked": "AniList'da kuzatilmoqda"
+    "anilist_tracked": "AniList'da kuzatilmoqda",
+    "following_on": "Kuzatilyapti",
+    "following_off": "Kuzatilmayapti",
+    "no_screenshots": "Kadrlar yo‘q",
+    "show_more": "Ko‘proq",
+    "show_less": "Yig‘ish"
   },
   "shorts": {
     "refresh": "Yangilash",
@@ -1006,7 +1038,11 @@
     "episodes_count": "{count} qism",
     "reminder_body": "{episode}-qism 10 daqiqadan keyin chiqadi",
     "reminders_on": "Qism chiqishidan oldin eslatilsin",
-    "reminders_off": "Eslatmalar o‘chiq"
+    "reminders_off": "Eslatmalar o‘chiq",
+    "connect_first": "Avval AniList’ni ulang",
+    "save_failed": "AniList’ga saqlab bo‘lmadi",
+    "search_in_source": "BITTA MANBADA QIDIRISH",
+    "no_sources": "Hali manba o‘rnatilmagan"
   },
   "tracker": {
     "title": "Tracking",
@@ -1051,5 +1087,17 @@
     "empty": "Hozircha kanal yo‘q.",
     "load_failed": "Kanallarni yuklab bo‘lmadi.",
     "retry": "Qayta urinish"
+  },
+  "time": {
+    "now": "hozirgina",
+    "minutes": "{} daqiqa oldin",
+    "hours": "{} soat oldin",
+    "days": "{} kun oldin"
+  },
+  "user_lists": {
+    "title": "Ro‘yxatlarim",
+    "remove": "O‘chirish",
+    "empty_title": "Hozircha hech narsa yo‘q",
+    "empty_subtitle": "Saqlaganlaringiz shu yerda ko‘rinadi."
   }
 }

--- a/lib/core/js/dart_fetch.dart
+++ b/lib/core/js/dart_fetch.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
+import 'package:soplay/core/network/user_agent.dart';
 
 import '../network/cf_bypass_service.dart';
 import 'js_log.dart';
@@ -14,6 +15,22 @@ class DartFetch {
   final Dio? _backendDio;
 
   final Map<String, String> _savedCookies = {};
+
+  /// The last request the network refused outright.
+  ///
+  /// Extensions parse whatever body they are handed, so a 403 or an unsolved
+  /// challenge page reaches them as "nothing matched" rather than as a failure.
+  /// Remembering it here is the only place that can still tell the two apart by
+  /// the time a caller sees an empty list.
+  String? _lastBlock;
+
+  String? takeBlock() {
+    final block = _lastBlock;
+    _lastBlock = null;
+    return block;
+  }
+
+  void clearBlock() => _lastBlock = null;
 
   DartFetch._(this._dio, this._cfService, this._backendDio);
 
@@ -29,6 +46,9 @@ class DartFetch {
         maxRedirects: 10,
         validateStatus: (_) => true,
         responseType: ResponseType.plain,
+        // Without this dart:io stamps `Dart/3.x (dart:io)` on every extension
+        // request, which Cloudflare refuses outright.
+        headers: const {'User-Agent': kSozoUserAgent},
       ),
     )..interceptors.add(SafeCookieManager(CookieJar()));
     return DartFetch._(dio, cfService, backendDio);
@@ -82,18 +102,32 @@ class DartFetch {
           cf != null &&
           _looksLikeCfChallenge(status, headers, response.data)) {
         JsLog.req('fetch', 'CF challenge on $host — solving …');
+        final solveAgent = req.headers['User-Agent'] ??
+            req.headers['user-agent'] ??
+            kSozoUserAgent;
         final cookieHeader = await cf.solve(
           host: host,
           url: req.url,
-          userAgent: req.headers['User-Agent'] ??
-              req.headers['user-agent'] ??
-              'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36',
+          userAgent: solveAgent,
         );
         if (cookieHeader != null) {
           _savedCookies[host] = cookieHeader;
           unawaited(_pushCookiesToBackend(host, cookieHeader, req.headers));
-          return _send(req, allowCfRetry: false);
+          // Replay under the SAME agent that earned the clearance. Sending a
+          // different one makes Cloudflare reissue the challenge, and with
+          // allowCfRetry false there is no third attempt — the challenge HTML
+          // goes to the extension, which parses nothing out of it.
+          return _send(
+            req.copyWithHeader('User-Agent', solveAgent),
+            allowCfRetry: false,
+          );
         }
+      }
+
+      if (_looksLikeCfChallenge(status, headers, response.data)) {
+        _lastBlock = '${host ?? 'server'} is behind a Cloudflare challenge';
+      } else if (status >= 400) {
+        _lastBlock = '${host ?? 'server'} refused the request ($status)';
       }
 
       JsLog.res(
@@ -109,15 +143,43 @@ class DartFetch {
       };
     } catch (e) {
       JsLog.err('fetch', '${req.method} ${_shortUrl(req.url)} — $e');
+      _lastBlock = '${host ?? 'network'}: ${_shortError(e)}';
       return const {'status': 0, 'data': null, 'headers': {}};
     }
+  }
+
+  static String _shortError(Object e) {
+    if (e is DioException) {
+      return switch (e.type) {
+        DioExceptionType.connectionTimeout ||
+        DioExceptionType.sendTimeout ||
+        DioExceptionType.receiveTimeout => 'timed out',
+        DioExceptionType.connectionError => 'unreachable',
+        DioExceptionType.badCertificate => 'bad certificate',
+        _ => e.message ?? 'request failed',
+      };
+    }
+    return '$e';
   }
 
   bool _looksLikeCfChallenge(int status, Map<String, String> headers, String? body) {
     if (status == 428 && body != null && body.contains('cfChallenge')) {
       return true;
     }
-    if (status != 403 && status != 503) return false;
+    // Cloudflare sets this whenever it interfered, whatever the status.
+    if (headers['cf-mitigated']?.isNotEmpty ?? false) return true;
+    // A managed challenge is routinely served as 200 or 429. Gating the body
+    // sniff on 403/503 alone let those through as a successful response, and
+    // the extension then parsed the challenge page and found nothing in it.
+    if (status != 403 && status != 503 && status != 429 && status != 200) {
+      return false;
+    }
+    if (status == 200 || status == 429) {
+      if (body == null) return false;
+      return body.contains('cdn-cgi/challenge-platform') ||
+          body.contains('__cf_chl_') ||
+          body.contains('Just a moment...');
+    }
     final server = (headers['server'] ?? '').toLowerCase();
     if (server.contains('cloudflare')) return true;
     if (body == null) return false;
@@ -206,4 +268,13 @@ class _Request {
     required this.headers,
     this.body,
   });
+
+  /// The same request with one header set. Used to replay a Cloudflare-blocked
+  /// call under the agent that solved the challenge.
+  _Request copyWithHeader(String name, String value) => _Request(
+    method: method,
+    url: url,
+    headers: {...headers, name: value},
+    body: body,
+  );
 }

--- a/lib/core/js/js_runtime_service.dart
+++ b/lib/core/js/js_runtime_service.dart
@@ -11,6 +11,7 @@ import 'dart_fetch.dart';
 import 'extractor_cache.dart';
 import 'extractor_remote.dart';
 import 'js_log.dart';
+import 'js_timeouts.dart';
 import 'provider_registry.dart';
 
 class JsRuntimeService {
@@ -164,12 +165,13 @@ class JsRuntimeService {
     final sw = Stopwatch()..start();
     JsLog.req(tag, '$fn(${_summarizeArgs(args)})');
     try {
-      await ensureReady();
+      await ensureReady().timeout(kJsCallTimeout);
       // Serialize extractor-swap + call: concurrent cross-search legs share one
       // webview and one globalThis.Provider, so without this a second leg could
       // swap Provider between this leg's setup and its call — returning one
       // provider's results under another's name.
-      await _ensureExtractor(extractor.name, extractor.version);
+      await _ensureExtractor(extractor.name, extractor.version)
+          .timeout(kJsCallTimeout);
       // Unlocked on purpose. The provider is looked up by name, so several
       // cross-search legs can be in flight at once and their network waits
       // overlap instead of queueing — which is what made searching several
@@ -193,7 +195,7 @@ class JsRuntimeService {
           'fnName': fn,
           'fnArgs': args,
         },
-      );
+      ).timeout(kJsCallTimeout);
 
       if (result == null) {
         JsLog.err(tag, '$fn returned null result');

--- a/lib/core/js/js_timeouts.dart
+++ b/lib/core/js/js_timeouts.dart
@@ -1,0 +1,8 @@
+/// How long an extension call may take before the app stops waiting on it.
+///
+/// Nothing in either JS runtime was bounded, so a source that never answered
+/// left the screen it was loading on its skeleton indefinitely. Generous rather
+/// than tight: a single call can legitimately be several requests plus a
+/// Cloudflare solve, and cutting a slow-but-working source off reads as the
+/// same bug from the other side.
+const Duration kJsCallTimeout = Duration(seconds: 40);

--- a/lib/core/network/cf_bypass_interceptor.dart
+++ b/lib/core/network/cf_bypass_interceptor.dart
@@ -1,3 +1,4 @@
+import 'package:soplay/core/network/user_agent.dart';
 import 'package:dio/dio.dart';
 
 import 'cf_bypass_service.dart';
@@ -31,7 +32,7 @@ class CfBypassInterceptor extends Interceptor {
     final host = (data['host'] as String?)?.trim();
     final url  = (data['url']  as String?)?.trim();
     final ua   = (data['userAgent'] as String?)?.trim() ??
-        'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36';
+        kSozoUserAgent;
     if (host == null || host.isEmpty || url == null || url.isEmpty) {
       handler.next(err);
       return;

--- a/lib/core/network/user_agent.dart
+++ b/lib/core/network/user_agent.dart
@@ -1,0 +1,13 @@
+/// The single User-Agent this app presents.
+///
+/// Cloudflare binds cf_clearance to the exact User-Agent that solved the
+/// challenge, so a clearance earned under one and replayed under another is
+/// rejected. The Dart side carried five different strings — and the extension
+/// HTTP client carried none at all, which means dart:io stamped
+/// `Dart/3.x (dart:io)` on every request an extension made. Cloudflare and
+/// plenty of ordinary WAFs refuse that outright.
+///
+/// The Android TV app had the same disease and the same cure.
+const String kSozoUserAgent =
+    'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36';

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -176,8 +176,17 @@ class AppRouter {
       ),
       GoRoute(
         path: '/cross-search',
-        builder: (context, state) =>
-            CrossSearchPage(initialQuery: state.extra as String?),
+        builder: (context, state) {
+          // Either a bare query, or a query with the sources to search.
+          final extra = state.extra;
+          if (extra is CrossSearchRequest) {
+            return CrossSearchPage(
+              initialQuery: extra.query,
+              initialProviderIds: extra.providerIds,
+            );
+          }
+          return CrossSearchPage(initialQuery: extra as String?);
+        },
       ),
       GoRoute(
         path: '/following',

--- a/lib/features/anilist/presentation/controllers/anilist_library_controller.dart
+++ b/lib/features/anilist/presentation/controllers/anilist_library_controller.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:soplay/features/anilist/data/anilist_api.dart';
@@ -85,7 +86,9 @@ class AnilistLibraryController extends ChangeNotifier {
     try {
       _entries = await _service.library();
     } catch (e) {
-      _error = e is AnilistException ? e.message : 'Could not load your AniList list';
+      _error = e is AnilistException
+          ? e.message
+          : 'anilist.calendar_list_error'.tr();
     } finally {
       _loading = false;
       notifyListeners();
@@ -103,7 +106,7 @@ class AnilistLibraryController extends ChangeNotifier {
   /// Writes an explicit progress value.
   Future<String?> setProgress(AnilistListEntry entry, int progress) async {
     final token = _service.token;
-    if (token == null) return 'AniList is not connected';
+    if (token == null) return 'anilist.connect_first'.tr();
     if (progress < 0 || _busy.contains(entry.id)) return null;
 
     final previous = entry;
@@ -124,7 +127,7 @@ class AnilistLibraryController extends ChangeNotifier {
       return null;
     } catch (e) {
       _replace(previous);
-      return e is AnilistException ? e.message : 'Could not save to AniList';
+      return e is AnilistException ? e.message : 'anilist.save_failed'.tr();
     } finally {
       _busy.remove(entry.id);
       notifyListeners();
@@ -134,7 +137,7 @@ class AnilistLibraryController extends ChangeNotifier {
   /// Moves an entry to another list.
   Future<String?> setStatus(AnilistListEntry entry, AnilistStatus status) async {
     final token = _service.token;
-    if (token == null) return 'AniList is not connected';
+    if (token == null) return 'anilist.connect_first'.tr();
     if (_busy.contains(entry.id)) return null;
 
     final previous = entry;
@@ -153,7 +156,7 @@ class AnilistLibraryController extends ChangeNotifier {
       return null;
     } catch (e) {
       _replace(previous);
-      return e is AnilistException ? e.message : 'Could not save to AniList';
+      return e is AnilistException ? e.message : 'anilist.save_failed'.tr();
     } finally {
       _busy.remove(entry.id);
       notifyListeners();

--- a/lib/features/anilist/presentation/pages/airing_calendar_page.dart
+++ b/lib/features/anilist/presentation/pages/airing_calendar_page.dart
@@ -292,10 +292,25 @@ class _AiringCalendarPageState extends State<AiringCalendarPage>
               separatorBuilder: (_, _) => const SizedBox(height: 9),
               itemBuilder: (context, i) {
                 final row = rows[i];
-                final card = _AiringCard(
-                  row: row,
-                  mine: _calendar.isMine(row.airing.media.id),
-                  onTap: () => _openRow(row),
+                // The label is printed once per clock time. A column repeating
+                // 18:00 down six rows is noise; the line is what carries them.
+                final previous = i == 0 ? null : rows[i - 1].airing.airsAt;
+                final at = row.airing.airsAt;
+                final startsTime = previous == null ||
+                    previous.hour != at.hour ||
+                    previous.minute != at.minute;
+
+                final card = _TimeRailRow(
+                  at: at,
+                  showTime: startsTime,
+                  aired: row.airing.hasAired,
+                  first: i == 0,
+                  last: i == rows.length - 1,
+                  child: _AiringCard(
+                    row: row,
+                    mine: _calendar.isMine(row.airing.media.id),
+                    onTap: () => _openRow(row),
+                  ),
                 );
                 if (i != nowAt) return card;
                 return Column(
@@ -333,52 +348,20 @@ class _AiringCalendarPageState extends State<AiringCalendarPage>
           : 'anilist.calendar_empty'.tr();
     }
     final failed = error != null || listFailed;
+    final VoidCallback retry =
+        listFailed ? () => _library.load(force: true) : refresh;
 
     return RefreshIndicator(
       color: kAnilistBlue,
       backgroundColor: AppColors.surface,
       onRefresh: refresh,
-      child: ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: [
-          SizedBox(height: MediaQuery.sizeOf(context).height * 0.12),
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Column(
-                children: [
-                  Icon(
-                    failed ? Icons.cloud_off_rounded : Icons.event_busy_rounded,
-                    size: 46,
-                    color: AppColors.textHint.withValues(alpha: 0.6),
-                  ),
-                  const SizedBox(height: 14),
-                  Text(
-                    message,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: AppColors.textHint,
-                      fontSize: 13.5,
-                      height: 1.5,
-                    ),
-                  ),
-                  if (failed) ...[
-                    const SizedBox(height: 10),
-                    TextButton(
-                      onPressed: listFailed
-                          ? () => _library.load(force: true)
-                          : refresh,
-                      style: TextButton.styleFrom(
-                        foregroundColor: kAnilistBlue,
-                      ),
-                      child: Text('anilist.retry'.tr()),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ),
-        ],
+      child: AnilistScrollableMessage(
+        message: AnilistStateMessage(
+          icon: failed ? Icons.cloud_off_rounded : Icons.event_busy_rounded,
+          text: message,
+          actionLabel: failed ? 'anilist.retry'.tr() : null,
+          onAction: failed ? retry : null,
+        ),
       ),
     );
   }
@@ -401,6 +384,7 @@ class _AiringCalendarPageState extends State<AiringCalendarPage>
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: Colors.transparent,
+      isScrollControlled: true,
       builder: (_) => _MediaActions(
         media: media,
         onAdd: _service.isConnected ? () => _addToPlanning(media) : null,
@@ -452,7 +436,9 @@ class _DayStrip extends StatelessWidget {
     final days = controller.days;
 
     return SizedBox(
-      height: 76,
+      // The pill holds two stacked labels at a fixed height, so the height has
+      // to follow the text size the user chose or they overlap.
+      height: MediaQuery.textScalerOf(context).scale(52) + 24,
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
@@ -471,6 +457,10 @@ class _DayStrip extends StatelessWidget {
             button: true,
             selected: selected,
             label: DateFormat.yMMMMEEEEd(locale).format(day),
+            // ExcludeSemantics below drops the InkWell's own tap action along
+            // with its labels, which would leave the pill unusable by a screen
+            // reader.
+            onTap: () => controller.select(day),
             child: ExcludeSemantics(
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 160),
@@ -802,6 +792,112 @@ class _DaySkeleton extends StatelessWidget {
   }
 }
 
+/// The clock gutter beside a day's entries.
+///
+/// A day is a sequence in time, and a column of cards each carrying its own
+/// time pill did not say so — the reader had to compare numbers to work out the
+/// order. A continuous line with the hour printed where it changes reads as one
+/// descending timeline instead.
+class _TimeRailRow extends StatelessWidget {
+  const _TimeRailRow({
+    required this.at,
+    required this.showTime,
+    required this.aired,
+    required this.first,
+    required this.last,
+    required this.child,
+  });
+
+  final DateTime at;
+  final bool showTime;
+  final bool aired;
+  final bool first;
+  final bool last;
+  final Widget child;
+
+  static const double _railWidth = 52;
+  static const double _dotAt = 22;
+
+  @override
+  Widget build(BuildContext context) {
+    final colour = aired ? AppColors.textHint : kAnilistBlue;
+
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: _railWidth,
+            child: Stack(
+              children: [
+                // Two segments rather than one line: the run has to stop at the
+                // first and last entry, or it hangs off both ends of the day.
+                Positioned(
+                  left: _railWidth - 13,
+                  top: 0,
+                  height: _dotAt,
+                  child: _Segment(visible: !first),
+                ),
+                Positioned(
+                  left: _railWidth - 13,
+                  top: _dotAt,
+                  bottom: -9,
+                  child: _Segment(visible: !last),
+                ),
+                Positioned(
+                  left: _railWidth - 16,
+                  top: _dotAt - 3,
+                  child: Container(
+                    width: 7,
+                    height: 7,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: colour,
+                    ),
+                  ),
+                ),
+                if (showTime)
+                  Positioned(
+                    left: 0,
+                    right: 18,
+                    top: _dotAt - 8,
+                    child: Text(
+                      DateFormat.Hm(context.locale.toString()).format(at),
+                      textAlign: TextAlign.right,
+                      style: TextStyle(
+                        fontSize: 11.5,
+                        fontWeight: FontWeight.w800,
+                        color: colour,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+class _Segment extends StatelessWidget {
+  const _Segment({required this.visible});
+
+  final bool visible;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      color: visible
+          ? AppColors.textHint.withValues(alpha: 0.28)
+          : Colors.transparent,
+    );
+  }
+}
+
 class _AiringCard extends StatelessWidget {
   const _AiringCard({
     required this.row,
@@ -817,7 +913,6 @@ class _AiringCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final airing = row.airing;
     final media = airing.media;
-    final time = DateFormat.Hm(context.locale.toString()).format(airing.airsAt);
     final aired = airing.hasAired;
     final episode = row.isRange
         ? 'anilist.calendar_episode_range'.tr(
@@ -892,27 +987,6 @@ class _AiringCard extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(width: 10),
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 9,
-                  vertical: 5,
-                ),
-                decoration: BoxDecoration(
-                  color: aired
-                      ? AppColors.surfaceVariant
-                      : kAnilistBlue.withValues(alpha: 0.14),
-                  borderRadius: BorderRadius.circular(9),
-                ),
-                child: Text(
-                  time,
-                  style: TextStyle(
-                    fontSize: 12.5,
-                    fontWeight: FontWeight.w800,
-                    color: aired ? AppColors.textHint : kAnilistBlue,
-                  ),
-                ),
-              ),
             ],
           ),
         ),
@@ -943,72 +1017,76 @@ class _MediaActions extends StatelessWidget {
           borderRadius: BorderRadius.vertical(top: Radius.circular(22)),
         ),
         padding: const EdgeInsets.fromLTRB(18, 10, 18, 14),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: Container(
-                width: 38,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: AppColors.border,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-            ),
-            const SizedBox(height: 18),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AnilistCover(url: media.coverImage, width: 54),
-                const SizedBox(width: 13),
-                Expanded(
-                  child: Text(
-                    media.displayTitle,
-                    maxLines: 3,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: AppColors.textPrimary,
-                      fontSize: 15.5,
-                      fontWeight: FontWeight.w800,
-                      height: 1.25,
-                    ),
+        // Scrolls rather than clips: a three-line title, a large text scale or
+        // a landscape phone all put this past the height a sheet is given.
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppColors.border,
+                    borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            const Divider(color: AppColors.divider, height: 1),
-            _SheetAction(
-              icon: Icons.travel_explore_rounded,
-              label: 'anilist.find_in_sources'.tr(),
-              subtitle: 'anilist.find_in_sources_hint'.tr(),
-              onTap: () {
-                Navigator.of(context).pop();
-                context.push('/cross-search', extra: media.displayTitle);
-              },
-            ),
-            if (onAdd != null)
+              ),
+              const SizedBox(height: 18),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AnilistCover(url: media.coverImage, width: 54),
+                  const SizedBox(width: 13),
+                  Expanded(
+                    child: Text(
+                      media.displayTitle,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 15.5,
+                        fontWeight: FontWeight.w800,
+                        height: 1.25,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const Divider(color: AppColors.divider, height: 1),
               _SheetAction(
-                icon: Icons.bookmark_add_outlined,
-                label: 'anilist.calendar_add_planning'.tr(),
+                icon: Icons.travel_explore_rounded,
+                label: 'anilist.find_in_sources'.tr(),
+                subtitle: 'anilist.find_in_sources_hint'.tr(),
                 onTap: () {
                   Navigator.of(context).pop();
-                  onAdd!();
+                  context.push('/cross-search', extra: media.displayTitle);
                 },
               ),
-            _SheetAction(
-              icon: Icons.open_in_new_rounded,
-              label: 'anilist.open_on_anilist'.tr(),
-              onTap: siteUrl == null
-                  ? null
-                  : () => launchUrl(
-                      Uri.parse(siteUrl),
-                      mode: LaunchMode.externalApplication,
-                    ),
-            ),
-          ],
+              if (onAdd != null)
+                _SheetAction(
+                  icon: Icons.bookmark_add_outlined,
+                  label: 'anilist.calendar_add_planning'.tr(),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    onAdd!();
+                  },
+                ),
+              _SheetAction(
+                icon: Icons.open_in_new_rounded,
+                label: 'anilist.open_on_anilist'.tr(),
+                onTap: siteUrl == null
+                    ? null
+                    : () => launchUrl(
+                        Uri.parse(siteUrl),
+                        mode: LaunchMode.externalApplication,
+                      ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/anilist/presentation/pages/anilist_browse_page.dart
+++ b/lib/features/anilist/presentation/pages/anilist_browse_page.dart
@@ -1,3 +1,8 @@
+import 'package:soplay/features/search/presentation/pages/cross_search_page.dart';
+import 'package:soplay/features/profile/presentation/bloc/provider_state.dart';
+import 'package:soplay/features/profile/presentation/bloc/provider_bloc.dart';
+import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -55,6 +60,11 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
     _load(_shelf);
   }
 
+  /// Loads one shelf.
+  ///
+  /// Every state write is guarded on the shelf still being the selected one:
+  /// switching tabs while a fetch is in flight used to let the old answer clear
+  /// the spinner over the new tab and declare it empty.
   Future<void> _load(_Shelf shelf, {bool force = false}) async {
     if (!force && _cache.containsKey(shelf)) return;
     setState(() {
@@ -77,14 +87,24 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
       if (!mounted) return;
       setState(() {
         _cache[shelf] = media;
-        _loading = false;
+        if (shelf == _shelf) _loading = false;
       });
     } catch (e) {
       if (!mounted) return;
+      if (shelf != _shelf) return;
+      final message =
+          e is AnilistException ? e.message : 'anilist.browse_failed'.tr();
       setState(() {
         _loading = false;
-        _error = e is AnilistException ? e.message : 'anilist.browse_failed'.tr();
+        _error = message;
       });
+      // A failed refresh over a shelf that still holds titles has nowhere else
+      // to show: the grid keeps rendering what it has.
+      if (_cache[shelf]?.isNotEmpty ?? false) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+        );
+      }
     }
   }
 
@@ -130,30 +150,41 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
                 itemBuilder: (context, i) {
                   final shelf = _Shelf.values[i];
                   final active = shelf == _shelf;
-                  return GestureDetector(
-                    onTap: () {
-                      setState(() => _shelf = shelf);
-                      _load(shelf);
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 14),
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: active
-                            ? kAnilistBlue.withValues(alpha: 0.16)
-                            : AppColors.surface,
-                        borderRadius: BorderRadius.circular(20),
-                        border: Border.all(
-                          color: active ? kAnilistBlue : Colors.transparent,
-                          width: 1.2,
+                  return Material(
+                    color: active
+                        ? kAnilistBlue.withValues(alpha: 0.16)
+                        : AppColors.surface,
+                    borderRadius: BorderRadius.circular(20),
+                    clipBehavior: Clip.antiAlias,
+                    child: InkWell(
+                      onTap: () {
+                        if (shelf == _shelf) return;
+                        setState(() {
+                          _shelf = shelf;
+                          _error = null;
+                          _loading = false;
+                        });
+                        _load(shelf);
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 14),
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(
+                            color: active ? kAnilistBlue : Colors.transparent,
+                            width: 1.2,
+                          ),
                         ),
-                      ),
-                      child: Text(
-                        _label(shelf),
-                        style: TextStyle(
-                          fontSize: 12.5,
-                          fontWeight: FontWeight.w700,
-                          color: active ? kAnilistBlue : AppColors.textSecondary,
+                        child: Text(
+                          _label(shelf),
+                          style: TextStyle(
+                            fontSize: 12.5,
+                            fontWeight: FontWeight.w700,
+                            color: active
+                                ? kAnilistBlue
+                                : AppColors.textSecondary,
+                          ),
                         ),
                       ),
                     ),
@@ -175,17 +206,31 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
       );
     }
     if (_error != null && items.isEmpty) {
-      return _Message(
-        text: _error!,
-        onRetry: () => _load(_shelf, force: true),
+      return AnilistScrollableMessage(
+        message: AnilistStateMessage(
+          icon: Icons.cloud_off_rounded,
+          text: _error!,
+          actionLabel: 'anilist.retry'.tr(),
+          onAction: () => _load(_shelf, force: true),
+        ),
       );
     }
     if (items.isEmpty) {
-      return _Message(text: 'anilist.browse_empty'.tr());
+      return AnilistScrollableMessage(
+        message: AnilistStateMessage(
+          icon: Icons.explore_off_rounded,
+          text: 'anilist.browse_empty'.tr(),
+        ),
+      );
     }
 
+    const gutter = 14.0;
+    const spacing = 10.0;
+    const gap = 6.0;
     final width = MediaQuery.sizeOf(context).width;
     final columns = width >= 900 ? 6 : (width >= 620 ? 5 : 3);
+    final cell = (width - gutter * 2 - spacing * (columns - 1)) / columns;
+    final caption = _MediaCard.reserveCaption(context);
 
     return RefreshIndicator(
       color: kAnilistBlue,
@@ -193,17 +238,20 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
       onRefresh: () => _load(_shelf, force: true),
       child: GridView.builder(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.fromLTRB(14, 12, 14, 28),
+        padding: const EdgeInsets.fromLTRB(gutter, 12, gutter, 28),
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: columns,
           mainAxisSpacing: 12,
-          crossAxisSpacing: 10,
-          // Poster plus two lines of caption.
-          childAspectRatio: 0.5,
+          crossAxisSpacing: spacing,
+          // A 2:3 poster plus exactly two lines of caption. The old fixed
+          // ratio made the cell taller than that, and the cover stretched to
+          // fill it — the one thing AnilistCover exists to prevent.
+          childAspectRatio: cell / (cell * 3 / 2 + gap + caption),
         ),
         itemCount: items.length,
         itemBuilder: (context, i) => _MediaCard(
           media: items[i],
+          captionHeight: caption,
           onTap: () => _openSheet(items[i]),
         ),
       ),
@@ -224,9 +272,22 @@ class _AnilistBrowsePageState extends State<AnilistBrowsePage> {
 }
 
 class _MediaCard extends StatelessWidget {
-  const _MediaCard({required this.media, required this.onTap});
+  const _MediaCard({
+    required this.media,
+    required this.captionHeight,
+    required this.onTap,
+  });
+
+  static const double _fontSize = 11.5;
+  static const double _lineHeight = 1.2;
+
+  /// Two lines, always — a one-line title would otherwise let its poster grow
+  /// taller than its neighbours' and break the row.
+  static double reserveCaption(BuildContext context) =>
+      MediaQuery.textScalerOf(context).scale(_fontSize) * _lineHeight * 2;
 
   final AnilistMedia media;
+  final double captionHeight;
   final VoidCallback onTap;
 
   @override
@@ -272,15 +333,18 @@ class _MediaCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          Text(
-            title,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              fontSize: 11.5,
-              height: 1.2,
-              fontWeight: FontWeight.w600,
-              color: AppColors.textPrimary,
+          SizedBox(
+            height: captionHeight,
+            child: Text(
+              title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: _fontSize,
+                height: _lineHeight,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
             ),
           ),
         ],
@@ -309,8 +373,19 @@ class _MediaSheet extends StatelessWidget {
       maxChildSize: 0.92,
       builder: (context, scroll) => ListView(
         controller: scroll,
-        padding: const EdgeInsets.fromLTRB(16, 14, 16, 28),
+        padding: const EdgeInsets.fromLTRB(16, 10, 16, 28),
         children: [
+          Center(
+            child: Container(
+              width: 38,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 18),
+              decoration: BoxDecoration(
+                color: AppColors.border,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -357,17 +432,39 @@ class _MediaSheet extends StatelessWidget {
           // The bridge. Discovering something you cannot then open is a dead
           // end, and the source apps know nothing about AniList ids — the title
           // is what crosses.
-          SizedBox(
-            width: double.infinity,
-            height: 46,
-            child: ElevatedButton.icon(
-              onPressed: () {
-                Navigator.of(context).pop();
-                context.push('/cross-search', extra: title);
-              },
-              icon: const Icon(Icons.travel_explore_rounded, size: 19),
-              label: Text('anilist.find_in_sources'.tr()),
-            ),
+          Row(
+            children: [
+              Expanded(
+                child: SizedBox(
+                  height: 46,
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      context.push('/cross-search', extra: title);
+                    },
+                    icon: const Icon(Icons.travel_explore_rounded, size: 19),
+                    label: Text('anilist.find_in_sources'.tr()),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              // Searching every installed source buries the answer when you
+              // already know which one carries this. The caret narrows it to one.
+              SizedBox(
+                height: 46,
+                width: 46,
+                child: OutlinedButton(
+                  onPressed: () => _pickSource(context, title),
+                  style: OutlinedButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: const Icon(Icons.expand_more_rounded, size: 20),
+                ),
+              ),
+            ],
           ),
 
           if (description.isNotEmpty) ...[
@@ -387,45 +484,77 @@ class _MediaSheet extends StatelessWidget {
   }
 }
 
-class _Message extends StatelessWidget {
-  const _Message({required this.text, this.onRetry});
 
-  final String text;
-  final VoidCallback? onRetry;
+/// Lets the caller name the source before the search runs.
+///
+/// The provider list comes from the same bloc the search screens read, so a
+/// source the user has not installed is never offered.
+Future<void> _pickSource(BuildContext context, String title) async {
+  final state = context.read<ProviderBloc>().state;
+  final providers = state is ProviderLoaded
+      ? state.usableProviders
+      : const <ProviderEntity>[];
 
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.explore_off_rounded,
-              size: 46,
-              color: AppColors.textHint.withValues(alpha: 0.6),
-            ),
-            const SizedBox(height: 14),
-            Text(
-              text,
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                color: AppColors.textHint,
-                fontSize: 13.5,
-                height: 1.5,
-              ),
-            ),
-            if (onRetry != null) ...[
-              const SizedBox(height: 14),
-              OutlinedButton(
-                onPressed: onRetry,
-                child: Text('anilist.retry'.tr()),
-              ),
-            ],
-          ],
-        ),
+  if (providers.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('anilist.no_sources'.tr()),
+        behavior: SnackBarBehavior.floating,
       ),
     );
+    return;
   }
+
+  final picked = await showModalBottomSheet<String>(
+    context: context,
+    backgroundColor: AppColors.surface,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (sheetContext) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(18, 16, 18, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'anilist.search_in_source'.tr(),
+                style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0.8,
+                  color: AppColors.textHint,
+                ),
+              ),
+            ),
+          ),
+          Flexible(
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: providers.length,
+              itemBuilder: (_, i) => ListTile(
+                leading: const Icon(
+                  Icons.dns_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: Text(providers[i].name),
+                onTap: () => Navigator.of(sheetContext).pop(providers[i].id),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    ),
+  );
+
+  if (picked == null || !context.mounted) return;
+  Navigator.of(context).pop();
+  context.push(
+    '/cross-search',
+    extra: CrossSearchRequest(query: title, providerIds: {picked}),
+  );
 }

--- a/lib/features/anilist/presentation/pages/anilist_library_page.dart
+++ b/lib/features/anilist/presentation/pages/anilist_library_page.dart
@@ -219,11 +219,18 @@ class _StatusList extends StatelessWidget {
 
     final error = controller.error;
     if (error != null && controller.entries.isEmpty) {
-      return _Message(
-        icon: Icons.cloud_off_rounded,
-        text: error,
-        actionLabel: 'anilist.retry'.tr(),
-        onAction: onRefresh,
+      return RefreshIndicator(
+        color: kAnilistBlue,
+        backgroundColor: AppColors.surface,
+        onRefresh: onRefresh,
+        child: AnilistScrollableMessage(
+          message: AnilistStateMessage(
+            icon: Icons.cloud_off_rounded,
+            text: error,
+            actionLabel: 'anilist.retry'.tr(),
+            onAction: onRefresh,
+          ),
+        ),
       );
     }
 
@@ -233,16 +240,12 @@ class _StatusList extends StatelessWidget {
         color: kAnilistBlue,
         backgroundColor: AppColors.surface,
         onRefresh: onRefresh,
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: [
-            SizedBox(height: MediaQuery.sizeOf(context).height * 0.16),
-            _Message(
-              icon: Icons.inbox_rounded,
-              text: 'anilist.empty_status'
-                  .tr(args: [status.labelKey.tr().toLowerCase()]),
-            ),
-          ],
+        child: AnilistScrollableMessage(
+          message: AnilistStateMessage(
+            icon: Icons.inbox_rounded,
+            text: 'anilist.empty_status'
+                .tr(args: [status.labelKey.tr().toLowerCase()]),
+          ),
         ),
       );
     }
@@ -424,64 +427,13 @@ class _LoadingList extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(14, 12, 14, 28),
       itemCount: 6,
       separatorBuilder: (_, _) => const SizedBox(height: 10),
+      // Matches the real card: 10 of padding either side of a 54-wide 2:3
+      // cover. A skeleton of a different height defeats its own purpose.
       itemBuilder: (_, _) => Container(
-        height: 91,
+        height: 54 * 3 / 2 + 20,
         decoration: BoxDecoration(
           color: AppColors.surface,
           borderRadius: BorderRadius.circular(14),
-        ),
-      ),
-    );
-  }
-}
-
-class _Message extends StatelessWidget {
-  const _Message({
-    required this.icon,
-    required this.text,
-    this.actionLabel,
-    this.onAction,
-  });
-
-  final IconData icon;
-  final String text;
-  final String? actionLabel;
-  final VoidCallback? onAction;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: 46, color: AppColors.textHint.withValues(alpha: 0.6)),
-            const SizedBox(height: 14),
-            Text(
-              text,
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                color: AppColors.textHint,
-                fontSize: 13.5,
-                height: 1.5,
-              ),
-            ),
-            if (actionLabel != null && onAction != null) ...[
-              const SizedBox(height: 16),
-              OutlinedButton(
-                onPressed: onAction,
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: kAnilistBlue,
-                  side: BorderSide(color: kAnilistBlue.withValues(alpha: 0.5)),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                ),
-                child: Text(actionLabel!),
-              ),
-            ],
-          ],
         ),
       ),
     );

--- a/lib/features/anilist/presentation/pages/anilist_links_page.dart
+++ b/lib/features/anilist/presentation/pages/anilist_links_page.dart
@@ -51,17 +51,9 @@ class _AnilistLinksPageState extends State<AnilistLinksPage> {
       ),
       body: _items.isEmpty
           ? Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Text(
-                  'anilist.linked_titles_none'.tr(),
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: AppColors.textHint,
-                    fontSize: 13.5,
-                    height: 1.5,
-                  ),
-                ),
+              child: AnilistStateMessage(
+                icon: Icons.link_off_rounded,
+                text: 'anilist.linked_titles_none'.tr(),
               ),
             )
           : ListView.separated(

--- a/lib/features/anilist/presentation/pages/upcoming_page.dart
+++ b/lib/features/anilist/presentation/pages/upcoming_page.dart
@@ -106,39 +106,22 @@ class _UpcomingPageState extends State<UpcomingPage> {
     Future<void> refresh() => _controller.load(force: true);
 
     if (entries.isEmpty) {
+      // A load failure and an empty schedule are not the same state: the old
+      // shape put the error text under a "nothing airs" icon with no way back.
+      final error = _controller.error;
       return RefreshIndicator(
         color: kAnilistBlue,
         backgroundColor: AppColors.surface,
         onRefresh: refresh,
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: [
-            SizedBox(height: MediaQuery.sizeOf(context).height * 0.18),
-            Center(
-              child: Padding(
-                padding: const EdgeInsets.all(32),
-                child: Column(
-                  children: [
-                    Icon(
-                      Icons.event_available_rounded,
-                      size: 46,
-                      color: AppColors.textHint.withValues(alpha: 0.6),
-                    ),
-                    const SizedBox(height: 14),
-                    Text(
-                      _controller.error ?? 'anilist.upcoming_empty'.tr(),
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: AppColors.textHint,
-                        fontSize: 13.5,
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
+        child: AnilistScrollableMessage(
+          message: AnilistStateMessage(
+            icon: error != null
+                ? Icons.cloud_off_rounded
+                : Icons.event_available_rounded,
+            text: error ?? 'anilist.upcoming_empty'.tr(),
+            actionLabel: error == null ? null : 'anilist.retry'.tr(),
+            onAction: error == null ? null : refresh,
+          ),
         ),
       );
     }
@@ -267,7 +250,7 @@ class _UpcomingCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                DateFormat.Hm().format(airing.airsAt),
+                DateFormat.Hm(context.locale.toString()).format(airing.airsAt),
                 style: const TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 13,

--- a/lib/features/anilist/presentation/widgets/anilist_brand.dart
+++ b/lib/features/anilist/presentation/widgets/anilist_brand.dart
@@ -135,6 +135,99 @@ class AnilistProgressBar extends StatelessWidget {
   }
 }
 
+/// "Nothing here" and "that failed", in the one shape every AniList screen
+/// uses. Each screen had grown its own icon, its own retry button and its own
+/// vertical offset for the same two states.
+class AnilistStateMessage extends StatelessWidget {
+  const AnilistStateMessage({
+    super.key,
+    required this.icon,
+    required this.text,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final IconData icon;
+  final String text;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 46, color: AppColors.textHint.withValues(alpha: 0.6)),
+          const SizedBox(height: 14),
+          Text(
+            text,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: AppColors.textHint,
+              fontSize: 13.5,
+              height: 1.5,
+            ),
+          ),
+          if (actionLabel != null && onAction != null) ...[
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onAction,
+              style: OutlinedButton.styleFrom(
+                foregroundColor: kAnilistBlue,
+                side: BorderSide(color: kAnilistBlue.withValues(alpha: 0.5)),
+                // The app's outlined buttons are full-width page actions; this
+                // one sits under a paragraph and should read as an aside.
+                minimumSize: const Size(0, 42),
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              child: Text(actionLabel!),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// [AnilistStateMessage] centred in a scroll view, so a screen with nothing in
+/// it can still be pulled to refresh and still be dragged where the scrollable
+/// drives a sheet.
+///
+/// Centres on the viewport rather than on a fraction of the screen height: the
+/// lists this replaces sit under a tab bar, a day strip or a filter row, and a
+/// screen fraction put the message somewhere different on each of them.
+class AnilistScrollableMessage extends StatelessWidget {
+  const AnilistScrollableMessage({
+    super.key,
+    required this.message,
+    this.controller,
+  });
+
+  final AnilistStateMessage message;
+  final ScrollController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) => ListView(
+        controller: controller,
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Center(child: message),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// The block shown wherever a screen needs an AniList connection it does not
 /// have. One widget so the message and the button never drift apart between
 /// the library, the upcoming list and the title screen.

--- a/lib/features/anilist/presentation/widgets/anilist_entry_sheet.dart
+++ b/lib/features/anilist/presentation/widgets/anilist_entry_sheet.dart
@@ -96,128 +96,133 @@ class _AnilistEntrySheetState extends State<AnilistEntrySheet> {
           borderRadius: BorderRadius.vertical(top: Radius.circular(22)),
         ),
         padding: const EdgeInsets.fromLTRB(18, 10, 18, 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: Container(
-                width: 38,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: AppColors.border,
-                  borderRadius: BorderRadius.circular(2),
+        // Scrolls rather than clips: six status pills, a three-line title and a
+        // large text scale together outrun the height a sheet is given, and a
+        // landscape phone outruns it on its own.
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppColors.border,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 18),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AnilistCover(url: media.coverImage, width: 68),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        media.displayTitle,
-                        maxLines: 3,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: AppColors.textPrimary,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w800,
-                          height: 1.25,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 6,
-                        runSpacing: 6,
-                        children: [
-                          AnilistChip(
-                            label: (AnilistStatus.fromValue(entry.status) ??
-                                    AnilistStatus.current)
-                                .labelKey
-                                .tr(),
+              const SizedBox(height: 18),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AnilistCover(url: media.coverImage, width: 68),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          media.displayTitle,
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: AppColors.textPrimary,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w800,
+                            height: 1.25,
                           ),
-                          if (media.format != null)
+                        ),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: [
                             AnilistChip(
-                              label: media.format!,
-                              color: AppColors.textSecondary,
+                              label: (AnilistStatus.fromValue(entry.status) ??
+                                      AnilistStatus.current)
+                                  .labelKey
+                                  .tr(),
                             ),
-                          if (media.averageScore != null)
-                            AnilistChip(
-                              label: '${media.averageScore}%',
-                              icon: Icons.star_rounded,
-                              color: AppColors.rating,
-                            ),
-                        ],
-                      ),
-                    ],
+                            if (media.format != null)
+                              AnilistChip(
+                                label: media.format!,
+                                color: AppColors.textSecondary,
+                              ),
+                            if (media.averageScore != null)
+                              AnilistChip(
+                                label: '${media.averageScore}%',
+                                icon: Icons.star_rounded,
+                                color: AppColors.rating,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 20),
-            _ProgressRow(
-              progress: entry.progress,
-              total: total,
-              busy: busy,
-              canDecrement: entry.progress > 0,
-              canIncrement: next != null,
-              onDecrement: () => _run(_c.setProgress(entry, entry.progress - 1)),
-              onIncrement: () => _run(_c.bumpEpisode(entry)),
-            ),
-            const SizedBox(height: 18),
-            Text(
-              'anilist.status_label'.tr(),
-              style: const TextStyle(
-                color: AppColors.textHint,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0.7,
+                ],
               ),
-            ),
-            const SizedBox(height: 10),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                for (final status in AnilistStatus.values)
-                  _StatusPill(
-                    label: status.labelKey.tr(),
-                    selected: entry.status == status.value,
-                    onTap: busy || entry.status == status.value
-                        ? null
-                        : () => _run(_c.setStatus(entry, status)),
-                  ),
-              ],
-            ),
-            const SizedBox(height: 20),
-            const Divider(color: AppColors.divider, height: 1),
-            const SizedBox(height: 8),
-            _Action(
-              icon: Icons.travel_explore_rounded,
-              label: 'anilist.find_in_sources'.tr(),
-              subtitle: 'anilist.find_in_sources_hint'.tr(),
-              onTap: () {
-                Navigator.of(context).pop();
-                context.push('/cross-search', extra: media.displayTitle);
-              },
-            ),
-            _Action(
-              icon: Icons.open_in_new_rounded,
-              label: 'anilist.open_on_anilist'.tr(),
-              onTap: media.siteUrl == null
-                  ? null
-                  : () => launchUrl(
-                        Uri.parse(media.siteUrl!),
-                        mode: LaunchMode.externalApplication,
-                      ),
-            ),
-          ],
+              const SizedBox(height: 20),
+              _ProgressRow(
+                progress: entry.progress,
+                total: total,
+                busy: busy,
+                canDecrement: entry.progress > 0,
+                canIncrement: next != null,
+                onDecrement: () => _run(_c.setProgress(entry, entry.progress - 1)),
+                onIncrement: () => _run(_c.bumpEpisode(entry)),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                'anilist.status_label'.tr(),
+                style: const TextStyle(
+                  color: AppColors.textHint,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.7,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final status in AnilistStatus.values)
+                    _StatusPill(
+                      label: status.labelKey.tr(),
+                      selected: entry.status == status.value,
+                      onTap: busy || entry.status == status.value
+                          ? null
+                          : () => _run(_c.setStatus(entry, status)),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              const Divider(color: AppColors.divider, height: 1),
+              const SizedBox(height: 8),
+              _Action(
+                icon: Icons.travel_explore_rounded,
+                label: 'anilist.find_in_sources'.tr(),
+                subtitle: 'anilist.find_in_sources_hint'.tr(),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  context.push('/cross-search', extra: media.displayTitle);
+                },
+              ),
+              _Action(
+                icon: Icons.open_in_new_rounded,
+                label: 'anilist.open_on_anilist'.tr(),
+                onTap: media.siteUrl == null
+                    ? null
+                    : () => launchUrl(
+                          Uri.parse(media.siteUrl!),
+                          mode: LaunchMode.externalApplication,
+                        ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/anilist/presentation/widgets/anilist_link_sheet.dart
+++ b/lib/features/anilist/presentation/widgets/anilist_link_sheet.dart
@@ -119,7 +119,8 @@ class _AnilistLinkSheetState extends State<AnilistLinkSheet> {
       if (!mounted || token != _token) return;
       setState(() {
         _searching = false;
-        _error = e is AnilistException ? e.message : 'anilist.retry'.tr();
+        _error =
+            e is AnilistException ? e.message : 'anilist.browse_failed'.tr();
       });
     }
   }
@@ -263,13 +264,36 @@ class _AnilistLinkSheetState extends State<AnilistLinkSheet> {
     );
   }
 
+  /// Every branch hands the sheet's controller to a scrollable, including the
+  /// ones with nothing to scroll: that controller is what drives the drag, and
+  /// without it the sheet cannot be resized or flung shut at all.
   Widget _buildResults(ScrollController scrollController) {
     if (_error != null) {
-      return _centered(_error!, action: () => _search(_query.text));
+      return AnilistScrollableMessage(
+        controller: scrollController,
+        message: AnilistStateMessage(
+          icon: Icons.cloud_off_rounded,
+          text: _error!,
+          actionLabel: 'anilist.retry'.tr(),
+          onAction: () => _search(_query.text),
+        ),
+      );
     }
     if (_results.isEmpty) {
-      if (_searching) return const SizedBox.shrink();
-      return _centered('anilist.link_no_results'.tr());
+      if (_searching) {
+        return ListView(
+          controller: scrollController,
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [],
+        );
+      }
+      return AnilistScrollableMessage(
+        controller: scrollController,
+        message: AnilistStateMessage(
+          icon: Icons.search_off_rounded,
+          text: 'anilist.link_no_results'.tr(),
+        ),
+      );
     }
 
     return ListView.separated(
@@ -284,37 +308,6 @@ class _AnilistLinkSheetState extends State<AnilistLinkSheet> {
       ),
     );
   }
-
-  Widget _centered(String text, {VoidCallback? action}) => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(28),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                text,
-                textAlign: TextAlign.center,
-                style: const TextStyle(
-                  color: AppColors.textHint,
-                  fontSize: 13.5,
-                  height: 1.5,
-                ),
-              ),
-              if (action != null) ...[
-                const SizedBox(height: 14),
-                OutlinedButton(
-                  onPressed: action,
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: kAnilistBlue,
-                    side: BorderSide(color: kAnilistBlue.withValues(alpha: 0.5)),
-                  ),
-                  child: Text('anilist.retry'.tr()),
-                ),
-              ],
-            ],
-          ),
-        ),
-      );
 }
 
 class _CurrentLink extends StatelessWidget {

--- a/lib/features/detail/presentation/pages/actor_page.dart
+++ b/lib/features/detail/presentation/pages/actor_page.dart
@@ -480,12 +480,28 @@ class _AvatarRing extends StatelessWidget {
         ),
         clipBehavior: Clip.antiAlias,
         child: image.isNotEmpty
-            ? Image.network(
-                image,
-                fit: BoxFit.cover,
-                errorBuilder: (_, _, _) => _AvatarInitials(initials: initials),
-                loadingBuilder: (_, child, chunk) =>
-                    chunk == null ? child : _AvatarInitials(initials: initials),
+            ? Stack(
+                fit: StackFit.expand,
+                children: [
+                  _AvatarInitials(initials: initials),
+                  Image.network(
+                    image,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, _, _) =>
+                        _AvatarInitials(initials: initials),
+                    // Initials snapping to a photo at 132px is the loudest
+                    // thing on the screen; fade instead.
+                    frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+                      if (wasSynchronouslyLoaded) return child;
+                      return AnimatedOpacity(
+                        opacity: frame == null ? 0 : 1,
+                        duration: const Duration(milliseconds: 240),
+                        curve: Curves.easeOut,
+                        child: child,
+                      );
+                    },
+                  ),
+                ],
               )
             : _AvatarInitials(initials: initials),
       ),
@@ -566,15 +582,31 @@ class _ActorTopBar extends StatelessWidget {
             height: kToolbarHeight - 12,
             child: Row(
               children: [
-                IconButton(
-                  onPressed: onBack,
-                  icon: const Icon(
-                    Icons.arrow_back_ios_new_rounded,
-                    color: Colors.white,
-                    size: 20,
+                // The hero behind this bar is tinted from the actor's photo and
+                // can come out pale, which left a bare white glyph with nothing
+                // to sit on. The disc keeps it readable whatever the palette.
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: Material(
+                    color: Colors.black.withValues(alpha: 0.42 * (1 - solid)),
+                    shape: const CircleBorder(),
+                    clipBehavior: Clip.antiAlias,
+                    child: InkWell(
+                      onTap: onBack,
+                      customBorder: const CircleBorder(),
+                      child: const SizedBox(
+                        width: 36,
+                        height: 36,
+                        child: Icon(
+                          Icons.arrow_back_ios_new_rounded,
+                          color: Colors.white,
+                          size: 18,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
-                const SizedBox(width: 4),
+                const SizedBox(width: 10),
                 Expanded(
                   child: Opacity(
                     opacity: titleOp,
@@ -687,15 +719,17 @@ class _ActorMovieCard extends StatelessWidget {
               height: 1.25,
             ),
           ),
-          if (movie.year != null)
-            Text(
-              movie.year.toString(),
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 10,
-                height: 1.3,
-              ),
+          // Always laid out: the poster is the Expanded child, so a missing
+          // year made that card's artwork taller than the rest of the row.
+          Text(
+            movie.year?.toString() ?? '',
+            maxLines: 1,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 10,
+              height: 1.3,
             ),
+          ),
         ],
       ),
     );

--- a/lib/features/detail/presentation/pages/detail_page.dart
+++ b/lib/features/detail/presentation/pages/detail_page.dart
@@ -190,6 +190,12 @@ class _DetailViewState extends State<_DetailView>
   late final TabController _tabController;
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _bodyPlayKey = GlobalKey();
+  final GlobalKey _tabStripKey = GlobalKey();
+
+  /// Scroll offset at which the tab strip reaches the app bar and pins.
+  /// Measured while scrolling; stays infinite until then so that a tab switch
+  /// before any scrolling never moves the page.
+  double _tabsPinOffset = double.infinity;
 
   final GlobalKey _listActionShowcaseKey = GlobalKey();
   late final String _showcaseScope = 'detail-private-${identityHashCode(this)}';
@@ -265,6 +271,22 @@ class _DetailViewState extends State<_DetailView>
   void _onTabChanged() {
     if (!_tabController.indexIsChanging) return;
     if (mounted) setState(() {});
+    _settleOnTabs();
+  }
+
+  /// Tabs differ wildly in height — thirty related posters against an empty
+  /// cast list. Switching while scrolled deep into a tall tab left the scroll
+  /// position past the end of the short one, and the viewport snapped. Riding
+  /// back to the tab strip lands on a position every tab can hold.
+  void _settleOnTabs() {
+    if (!_scrollController.hasClients) return;
+    if (!_tabsPinOffset.isFinite) return;
+    if (_scrollController.offset <= _tabsPinOffset) return;
+    _scrollController.animateTo(
+      _tabsPinOffset,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   double _swipeAccum = 0;
@@ -298,12 +320,19 @@ class _DetailViewState extends State<_DetailView>
       _collapse.value = v;
     }
 
+    final pinLine = MediaQuery.paddingOf(context).top + kToolbarHeight;
+    final stripBox =
+        _tabStripKey.currentContext?.findRenderObject() as RenderBox?;
+    if (stripBox != null && stripBox.hasSize) {
+      final top = stripBox.localToGlobal(Offset.zero).dy;
+      if (top > pinLine) _tabsPinOffset = offset + (top - pinLine);
+    }
+
     final renderBox =
         _bodyPlayKey.currentContext?.findRenderObject() as RenderBox?;
     if (renderBox != null && renderBox.hasSize) {
       final pos = renderBox.localToGlobal(Offset.zero);
-      final topThreshold =
-          MediaQuery.paddingOf(context).top + kToolbarHeight - 4;
+      final topThreshold = pinLine - 4;
       final hidden = (pos.dy + renderBox.size.height) < topThreshold;
       if (hidden != _showPill.value) {
         _showPill.value = hidden;
@@ -531,8 +560,8 @@ class _DetailViewState extends State<_DetailView>
     if (!mounted) return;
     setState(() => _isFollowing = !_isFollowing);
     _showSnack(_isFollowing
-        ? 'Following — you\'ll be notified of new episodes'
-        : 'Unfollowed');
+        ? 'detail.following_on'.tr()
+        : 'detail.following_off'.tr());
   }
 
   void _onShare() {
@@ -829,7 +858,8 @@ class _DetailViewState extends State<_DetailView>
               SliverPersistentHeader(
                 pinned: true,
                 delegate: _TabBarDelegate(
-                  TabBar(
+                  stripKey: _tabStripKey,
+                  tabBar: TabBar(
                     controller: _tabController,
                     isScrollable: true,
                     tabAlignment: TabAlignment.start,
@@ -1147,10 +1177,12 @@ class _CircleIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final enabled = onTap != null;
     return HoverTap(
       onTap: onTap,
       onLongPress: onLongPress,
       onSecondaryTap: onLongPress,
+      scale: enabled ? 1.04 : 1.0,
       child: ClipOval(
         child: BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
@@ -1158,7 +1190,11 @@ class _CircleIconButton extends StatelessWidget {
             width: 36,
             height: 36,
             color: Colors.black.withValues(alpha: 0.42),
-            child: Icon(icon, color: iconColor, size: 18),
+            child: Icon(
+              icon,
+              color: enabled ? iconColor : iconColor.withValues(alpha: 0.38),
+              size: 18,
+            ),
           ),
         ),
       ),
@@ -1224,8 +1260,9 @@ class _ActionPill extends StatelessWidget {
 }
 
 class _TabBarDelegate extends SliverPersistentHeaderDelegate {
-  const _TabBarDelegate(this.tabBar);
+  const _TabBarDelegate({required this.tabBar, required this.stripKey});
   final TabBar tabBar;
+  final GlobalKey stripKey;
 
   @override
   Widget build(
@@ -1234,6 +1271,7 @@ class _TabBarDelegate extends SliverPersistentHeaderDelegate {
     bool overlapsContent,
   ) {
     return Container(
+      key: stripKey,
       color: AppColors.background,
       child: Column(
         children: [
@@ -1367,6 +1405,10 @@ class _ErrorView extends StatelessWidget {
             child: Text(
               message,
               textAlign: TextAlign.center,
+              // Provider errors can be paragraphs long; unbounded they pushed
+              // Retry off the bottom of the Column.
+              maxLines: 6,
+              overflow: TextOverflow.ellipsis,
               style: const TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,

--- a/lib/features/detail/presentation/pages/episodes_page.dart
+++ b/lib/features/detail/presentation/pages/episodes_page.dart
@@ -338,10 +338,12 @@ class _EpisodesPageState extends State<EpisodesPage> {
                       ),
                       SliverList.separated(
                         itemCount: _episodes.length,
+                        // Indents line up with where the row's label starts:
+                        // 16 + 88 thumb + 12, or 16 + 44 number + 12.
                         separatorBuilder: (_, _) => Divider(
                           color: AppColors.divider,
                           height: 1,
-                          indent: _showImages ? 116 : 76,
+                          indent: _showImages ? 116 : 72,
                         ),
                         itemBuilder: (_, i) {
                           final isCurrent = _historyItem != null &&

--- a/lib/features/detail/presentation/pages/player_page.controls.dart
+++ b/lib/features/detail/presentation/pages/player_page.controls.dart
@@ -335,13 +335,15 @@ extension _PlayerControls on _PlayerPageState {
   }
 
   Widget _buildSpeedBoostBadge() {
+    // Clears the status bar / cutout: in portrait the badge landed under it.
+    final topInset = MediaQuery.paddingOf(context).top;
     return ValueListenableBuilder<bool>(
       valueListenable: _speedBoost,
       builder: (_, active, _) {
         return AnimatedPositioned(
           duration: const Duration(milliseconds: 220),
           curve: Curves.easeOutCubic,
-          top: active ? 24 : -80,
+          top: active ? topInset + 24 : -80,
           left: 0,
           right: 0,
           child: IgnorePointer(
@@ -566,6 +568,8 @@ extension _PlayerControls on _PlayerPageState {
   }
 
   Widget _buildSwipeIndicator() {
+    // In landscape the display cutout is on one of these two edges.
+    final insets = MediaQuery.paddingOf(context);
     return ValueListenableBuilder<_SwipeIndicator?>(
       valueListenable: _swipeIndicator,
       builder: (_, indicator, _) {
@@ -574,8 +578,8 @@ extension _PlayerControls on _PlayerPageState {
         return Positioned(
           top: 0,
           bottom: 0,
-          left: isBrightness ? 48 : null,
-          right: isBrightness ? null : 48,
+          left: isBrightness ? 48 + insets.left : null,
+          right: isBrightness ? null : 48 + insets.right,
           child: Center(
             child: Container(
               width: 40,
@@ -728,117 +732,133 @@ extension _PlayerControls on _PlayerPageState {
                             color: Colors.white,
                             fontSize: 15,
                             fontWeight: FontWeight.w700,
+                            shadows: _kControlShadow,
                           ),
                         ),
                       ),
-                      if (hasLangSwitcher) ...[
-                        _LangPill(
-                          label: (_currentLang ?? _kSubLang).toUpperCase(),
-                          onTap: _openLangSheet,
-                        ),
-                        const SizedBox(width: 8),
-                      ],
-                      // CloudStream (cs:) sources are excluded from Watch2Gether
-                      // for now (they need an on-device plugin per peer).
-                      if (_inParty || !widget.args.provider.startsWith('cs:')) ...[
-                        _IconButton(
-                          icon: _inParty
-                              ? Icons.groups_rounded
-                              : Icons.groups_2_outlined,
-                          color: _inParty ? AppColors.primary : null,
-                          onTap: _openWatchParty,
-                        ),
-                        const SizedBox(width: 8),
-                      ],
-                      // TV drops three phone-only affordances outright rather
-                      // than adapting them: orientation lock is meaningless on
-                      // a fixed landscape panel, PiP semantics differ on
-                      // leanback, and the touch lock swaps in an overlay whose
-                      // only escape is a non-focusable tap target — on a remote
-                      // that is an unrecoverable state.
-                      if (isTvPlatform) ...[
-                        _IconButton(
-                          icon: Icons.subtitles_outlined,
-                          onTap: _openSubtitleSheet,
-                        ),
-                        const SizedBox(width: 8),
-                        if (canDownload) ...[
-                          _IconButton(
-                            icon: Icons.download_rounded,
-                            onTap: _startDownload,
+                      // The action set outgrows a portrait phone (lang pill +
+                      // download + the full icon row), which used to squeeze the
+                      // title to nothing and then overflow. Half the bar each,
+                      // right-anchored, and the surplus scrolls instead.
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          reverse: true,
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (hasLangSwitcher) ...[
+                                _LangPill(
+                                  label: (_currentLang ?? _kSubLang).toUpperCase(),
+                                  onTap: _openLangSheet,
+                                ),
+                                const SizedBox(width: 8),
+                              ],
+                              // CloudStream (cs:) sources are excluded from Watch2Gether
+                              // for now (they need an on-device plugin per peer).
+                              if (_inParty || !widget.args.provider.startsWith('cs:')) ...[
+                                _IconButton(
+                                  icon: _inParty
+                                      ? Icons.groups_rounded
+                                      : Icons.groups_2_outlined,
+                                  color: _inParty ? AppColors.primary : null,
+                                  onTap: _openWatchParty,
+                                ),
+                                const SizedBox(width: 8),
+                              ],
+                              // TV drops three phone-only affordances outright rather
+                              // than adapting them: orientation lock is meaningless on
+                              // a fixed landscape panel, PiP semantics differ on
+                              // leanback, and the touch lock swaps in an overlay whose
+                              // only escape is a non-focusable tap target — on a remote
+                              // that is an unrecoverable state.
+                              if (isTvPlatform) ...[
+                                _IconButton(
+                                  icon: Icons.subtitles_outlined,
+                                  onTap: _openSubtitleSheet,
+                                ),
+                                const SizedBox(width: 8),
+                                if (canDownload) ...[
+                                  _IconButton(
+                                    icon: Icons.download_rounded,
+                                    onTap: _startDownload,
+                                  ),
+                                  const SizedBox(width: 8),
+                                ],
+                                _IconButton(
+                                  icon: Icons.settings_outlined,
+                                  onTap: _openSettingsSheet,
+                                ),
+                                if (hasServers) ...[
+                                  const SizedBox(width: 8),
+                                  _IconButton(
+                                    icon: Icons.dns_outlined,
+                                    onTap: _openServerSheet,
+                                  ),
+                                ],
+                                if (hasEpisodes || hasQualities) ...[
+                                  const SizedBox(width: 8),
+                                  _IconButton(
+                                    icon: hasEpisodes
+                                        ? Icons.video_library_rounded
+                                        : Icons.high_quality_rounded,
+                                    onTap: () => _openPanel(
+                                      hasEpisodes
+                                          ? _SidePanel.episodes
+                                          : _SidePanel.quality,
+                                    ),
+                                  ),
+                                ],
+                              ] else if (!isDesktopPlatform) ...[
+                                _IconButton(
+                                  icon: _isPortrait
+                                      ? Icons.screen_lock_landscape_rounded
+                                      : Icons.screen_lock_portrait_rounded,
+                                  onTap: _toggleOrientation,
+                                ),
+                                const SizedBox(width: 8),
+                                _IconButton(
+                                  icon: Icons.lock_outline_rounded,
+                                  onTap: () => setState(() {
+                                    _locked = true;
+                                    _controlsVisible = false;
+                                    _controlsAnimation.reverse();
+                                    _hideTimer?.cancel();
+                                  }),
+                                ),
+                                const SizedBox(width: 8),
+                                _IconButton(
+                                  icon: Icons.picture_in_picture_alt_rounded,
+                                  onTap: _enterPip,
+                                ),
+                                const SizedBox(width: 8),
+                                if (canDownload) ...[
+                                  _IconButton(
+                                    icon: Icons.download_rounded,
+                                    onTap: _startDownload,
+                                  ),
+                                  const SizedBox(width: 8),
+                                ],
+                                _IconButton(
+                                  icon: Icons.settings_outlined,
+                                  onTap: _openSettingsSheet,
+                                ),
+                                const SizedBox(width: 8),
+                                _IconButton(
+                                  icon: hasEpisodes
+                                      ? Icons.video_library_rounded
+                                      : Icons.high_quality_rounded,
+                                  onTap: hasEpisodes
+                                      ? () => _openPanel(_SidePanel.episodes)
+                                      : hasQualities
+                                          ? () => _openPanel(_SidePanel.quality)
+                                          : _openSettingsSheet,
+                                ),
+                              ],
+                            ],
                           ),
-                          const SizedBox(width: 8),
-                        ],
-                        _IconButton(
-                          icon: Icons.settings_outlined,
-                          onTap: _openSettingsSheet,
                         ),
-                        if (hasServers) ...[
-                          const SizedBox(width: 8),
-                          _IconButton(
-                            icon: Icons.dns_outlined,
-                            onTap: _openServerSheet,
-                          ),
-                        ],
-                        if (hasEpisodes || hasQualities) ...[
-                          const SizedBox(width: 8),
-                          _IconButton(
-                            icon: hasEpisodes
-                                ? Icons.video_library_rounded
-                                : Icons.high_quality_rounded,
-                            onTap: () => _openPanel(
-                              hasEpisodes
-                                  ? _SidePanel.episodes
-                                  : _SidePanel.quality,
-                            ),
-                          ),
-                        ],
-                      ] else if (!isDesktopPlatform) ...[
-                        _IconButton(
-                          icon: _isPortrait
-                              ? Icons.screen_lock_landscape_rounded
-                              : Icons.screen_lock_portrait_rounded,
-                          onTap: _toggleOrientation,
-                        ),
-                        const SizedBox(width: 8),
-                        _IconButton(
-                          icon: Icons.lock_outline_rounded,
-                          onTap: () => setState(() {
-                            _locked = true;
-                            _controlsVisible = false;
-                            _controlsAnimation.reverse();
-                            _hideTimer?.cancel();
-                          }),
-                        ),
-                        const SizedBox(width: 8),
-                        _IconButton(
-                          icon: Icons.picture_in_picture_alt_rounded,
-                          onTap: _enterPip,
-                        ),
-                        const SizedBox(width: 8),
-                        if (canDownload) ...[
-                          _IconButton(
-                            icon: Icons.download_rounded,
-                            onTap: _startDownload,
-                          ),
-                          const SizedBox(width: 8),
-                        ],
-                        _IconButton(
-                          icon: Icons.settings_outlined,
-                          onTap: _openSettingsSheet,
-                        ),
-                        const SizedBox(width: 8),
-                        _IconButton(
-                          icon: hasEpisodes
-                              ? Icons.video_library_rounded
-                              : Icons.high_quality_rounded,
-                          onTap: hasEpisodes
-                              ? () => _openPanel(_SidePanel.episodes)
-                              : hasQualities
-                                  ? () => _openPanel(_SidePanel.quality)
-                                  : _openSettingsSheet,
-                        ),
-                      ],
+                      ),
                       if (isDesktopPlatform)
                         ValueListenableBuilder<bool>(
                           valueListenable: DesktopWindow.immersive,
@@ -851,19 +871,7 @@ extension _PlayerControls on _PlayerPageState {
                 ),
               ),
             ),
-            if (initialized && !isBuffering && !isDesktopPlatform)
-              _buildCenterPlayCluster(c),
-            if (isBuffering)
-              const Center(
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: CircularProgressIndicator(
-                    color: Colors.white,
-                    strokeWidth: 2.8,
-                  ),
-                ),
-              ),
+            if (initialized && !isDesktopPlatform) _buildCenterPlayCluster(c),
             if (initialized)
               _buildBottomBar(c, hasEpisodes, hasServers, hasQualities),
           ],
@@ -871,10 +879,36 @@ extension _PlayerControls on _PlayerPageState {
       ),
     );
 
-    if (!isTvPlatform) return overlay;
     // IgnorePointer stops taps but leaves every button focusable, so on a
     // D-pad an invisible control would still take focus and fire on OK.
-    return ExcludeFocus(excluding: !_controlsVisible, child: overlay);
+    final gated = isTvPlatform
+        ? ExcludeFocus(excluding: !_controlsVisible, child: overlay)
+        : overlay;
+
+    if (!isBuffering) return gated;
+    // A stall while the controls are hidden used to show nothing at all — the
+    // spinner lived inside the overlay and faded out with it. This one sits
+    // outside the fade and cross-fades against it, so exactly one buffering
+    // indicator is on screen: this, or the ring on the play button.
+    Widget spinner = const IgnorePointer(
+      child: Center(
+        child: SizedBox(
+          width: 44,
+          height: 44,
+          child: CircularProgressIndicator(
+            color: Colors.white,
+            strokeWidth: 2.8,
+          ),
+        ),
+      ),
+    );
+    if (!isDesktopPlatform) {
+      spinner = FadeTransition(
+        opacity: ReverseAnimation(_controlsAnimation),
+        child: spinner,
+      );
+    }
+    return Stack(fit: StackFit.expand, children: [gated, spinner]);
   }
 
   Widget _buildCenterPlayCluster(PlayerController c) {
@@ -899,6 +933,7 @@ extension _PlayerControls on _PlayerPageState {
                   : Icons.play_arrow_rounded,
               onTap: _togglePlay,
               large: true,
+              busy: value.isBuffering,
               // Named so the remote can be parked here whenever the overlay
               // reappears; null off TV, i.e. the node is never even created.
               focusNode: isTvPlatform ? _tvPlayFocus : null,
@@ -1054,6 +1089,139 @@ extension _PlayerControls on _PlayerPageState {
     );
   }
 
+  /// Keeps the elapsed label as wide as the total one, so the bar does not jump
+  /// sideways the moment playback crosses an hour.
+  String _positionLabel(Duration position, Duration total) =>
+      total.inHours > 0 && position.inHours == 0
+          ? '00:${_formatDuration(position)}'
+          : _formatDuration(position);
+
+  /// End of the buffered range covering the playhead, or null when the engine
+  /// reports no ranges (media_kit does not publish them).
+  double? _bufferedMs(VideoPlayerValue value, double maxMs) {
+    final position = value.position.inMilliseconds;
+    var end = -1;
+    for (final range in value.buffered) {
+      if (range.start.inMilliseconds <= position &&
+          range.end.inMilliseconds > end) {
+        end = range.end.inMilliseconds;
+      }
+    }
+    return end < 0 ? null : end.toDouble().clamp(0.0, maxMs);
+  }
+
+  Widget? _buildScrubPreviewCard(Duration position) {
+    final thumb = _thumbnailAt(position);
+    final Widget? image = thumb != null
+        ? _buildThumbnailImage(thumb)
+        : _canGeneratePreview
+            ? _GeneratedFramePreview(
+                url: _videoUrl!,
+                headers: _headers,
+                positionMs: position.inMilliseconds,
+              )
+            : null;
+    if (image == null) return null;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ClipRRect(borderRadius: BorderRadius.circular(6), child: image),
+        const SizedBox(height: 4),
+        Text(
+          _formatDuration(position),
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            shadows: _kControlShadow,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// The seek bar, with the scrub preview floating above it.
+  ///
+  /// The preview is positioned out of the bar's own box instead of being a
+  /// sibling in the column: as a sibling it grew the bottom bar and shoved the
+  /// whole thing upward the instant a drag began — out from under the finger
+  /// holding the thumb. Measuring inside the bar's box also lines the popup up
+  /// with the thumb, which the previous guess at the label widths did not.
+  Widget _buildSeekBar({
+    required VideoPlayerValue value,
+    required double sliderVal,
+    required double maxMs,
+    required bool scrubbing,
+    required Duration previewPosition,
+  }) {
+    final Widget bar = isTvPlatform
+        ? _TvSeekBar(
+            focusNode: _tvSeekFocus,
+            positionMs: sliderVal,
+            durationMs: maxMs,
+            scrubbing: scrubbing,
+          )
+        : SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 4,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+              overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
+              activeTrackColor: AppColors.primary,
+              inactiveTrackColor: Colors.white24,
+              secondaryActiveTrackColor: Colors.white38,
+              thumbColor: Colors.white,
+              overlayColor: AppColors.primary.withValues(alpha: 0.2),
+            ),
+            child: Slider(
+              value: sliderVal,
+              min: 0,
+              max: maxMs,
+              secondaryTrackValue: _bufferedMs(value, maxMs),
+              onChangeStart: (v) {
+                _sliderDragValue.value = v;
+                _hideTimer?.cancel();
+              },
+              onChanged: (v) {
+                _sliderDragValue.value = v;
+                _hideTimer?.cancel();
+              },
+              onChangeEnd: (v) {
+                final target = Duration(milliseconds: v.toInt());
+                _seekTo(target);
+                _clearDragAfterSeek(target);
+              },
+            ),
+          );
+
+    final preview = scrubbing && (_hasThumbnails || _canGeneratePreview)
+        ? _buildScrubPreviewCard(previewPosition)
+        : null;
+
+    // The wrapper is unconditional: swapping it in when the preview appears
+    // would rebuild the slider mid-drag and drop the gesture.
+    return LayoutBuilder(
+      builder: (context, box) {
+        const previewWidth = 160.0;
+        // Each bar insets its track by its own overlay allowance.
+        final inset = isTvPlatform ? 24.0 : 16.0;
+        final track = (box.maxWidth - inset * 2).clamp(0.0, double.infinity);
+        final fraction = maxMs > 0 ? (sliderVal / maxMs).clamp(0.0, 1.0) : 0.0;
+        final left = (inset + fraction * track - previewWidth / 2).clamp(
+          0.0,
+          (box.maxWidth - previewWidth).clamp(0.0, double.infinity),
+        );
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            bar,
+            if (preview != null)
+              Positioned(left: left, bottom: 46, child: preview),
+          ],
+        );
+      },
+    );
+  }
+
   Widget _buildBottomBar(
     PlayerController c,
     bool hasEpisodes,
@@ -1081,6 +1249,7 @@ extension _PlayerControls on _PlayerPageState {
                   return ValueListenableBuilder<VideoPlayerValue>(
                     valueListenable: c,
                     builder: (_, value, _) {
+                      if (_isLive) return _buildLiveBar();
                       final duration = value.duration.inMilliseconds == 0
                           ? Duration.zero
                           : value.duration;
@@ -1097,134 +1266,34 @@ extension _PlayerControls on _PlayerPageState {
                           ? Duration(milliseconds: dragVal.toInt())
                           : value.position;
 
-                      return LayoutBuilder(
-                        builder: (context, constraints) {
-                        const sliderPad = 24.0;
-                        const thumbW = 160.0;
-                        final trackWidth =
-                            constraints.maxWidth - 80 - sliderPad * 2;
-                        final fraction = maxMs > 0
-                            ? (sliderVal / maxMs).clamp(0.0, 1.0)
-                            : 0.0;
-                        final thumbCenter =
-                            40 + sliderPad + fraction * trackWidth;
-                        final popupLeft = (thumbCenter - thumbW / 2)
-                            .clamp(0.0, constraints.maxWidth - thumbW);
-
-                        return Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: _isLive
-                            ? [_buildLiveBar()]
-                            : [
-                          if (dragVal != null && (_hasThumbnails || _canGeneratePreview))
-                            Builder(builder: (_) {
-                              final thumb = _thumbnailAt(displayPos);
-                              final Widget? img = thumb != null
-                                  ? _buildThumbnailImage(thumb)
-                                  : (_canGeneratePreview
-                                      ? _GeneratedFramePreview(
-                                          url: _videoUrl!,
-                                          headers: _headers,
-                                          positionMs: displayPos.inMilliseconds,
-                                        )
-                                      : null);
-                              if (img == null) {
-                                return const SizedBox.shrink();
-                              }
-                              return Padding(
-                                padding: EdgeInsets.only(
-                                    left: popupLeft, bottom: 6),
-                                child: Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: Column(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      ClipRRect(
-                                        borderRadius:
-                                            BorderRadius.circular(6),
-                                        child: img,
-                                      ),
-                                      const SizedBox(height: 4),
-                                      Text(
-                                        _formatDuration(displayPos),
-                                        style: const TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 11,
-                                          fontWeight: FontWeight.w700,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              );
-                            }),
-                          Row(
-                            children: [
-                              Text(
-                                _formatDuration(displayPos),
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 12,
-                                ),
-                              ),
-                              Expanded(
-                                child: isTvPlatform
-                                    ? _TvSeekBar(
-                                        focusNode: _tvSeekFocus,
-                                        positionMs: sliderVal.clamp(0.0, maxMs),
-                                        durationMs: maxMs,
-                                        scrubbing: dragVal != null,
-                                      )
-                                    : SliderTheme(
-                                  data: SliderTheme.of(context).copyWith(
-                                    trackHeight: 3,
-                                    thumbShape: const RoundSliderThumbShape(
-                                      enabledThumbRadius: 7,
-                                    ),
-                                    overlayShape:
-                                        const RoundSliderOverlayShape(
-                                      overlayRadius: 14,
-                                    ),
-                                    activeTrackColor: AppColors.primary,
-                                    inactiveTrackColor: Colors.white24,
-                                    thumbColor: Colors.white,
-                                    overlayColor: AppColors.primary.withValues(
-                                      alpha: 0.2,
-                                    ),
-                                  ),
-                                  child: Slider(
-                                    value: sliderVal.clamp(0.0, maxMs),
-                                    min: 0,
-                                    max: maxMs,
-                                    onChangeStart: (v) {
-                                      _sliderDragValue.value = v;
-                                      _hideTimer?.cancel();
-                                    },
-                                    onChanged: (v) {
-                                      _sliderDragValue.value = v;
-                                      _hideTimer?.cancel();
-                                    },
-                                    onChangeEnd: (v) {
-                                      final target = Duration(
-                                          milliseconds: v.toInt());
-                                      _seekTo(target);
-                                      _clearDragAfterSeek(target);
-                                    },
-                                  ),
-                                ),
-                              ),
-                              Text(
-                                _formatDuration(duration),
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ],
+                      return Row(
+                        children: [
+                          Text(
+                            _positionLabel(displayPos, duration),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              shadows: _kControlShadow,
+                            ),
+                          ),
+                          Expanded(
+                            child: _buildSeekBar(
+                              value: value,
+                              sliderVal: sliderVal.clamp(0.0, maxMs),
+                              maxMs: maxMs,
+                              scrubbing: dragVal != null,
+                              previewPosition: displayPos,
+                            ),
+                          ),
+                          Text(
+                            _formatDuration(duration),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              shadows: _kControlShadow,
+                            ),
                           ),
                         ],
-                      );
-                        },
                       );
                     },
                   );

--- a/lib/features/detail/presentation/pages/player_page.dart
+++ b/lib/features/detail/presentation/pages/player_page.dart
@@ -1,3 +1,4 @@
+import 'package:soplay/core/network/user_agent.dart';
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/features/detail/presentation/pages/player_page.gestures.dart
+++ b/lib/features/detail/presentation/pages/player_page.gestures.dart
@@ -90,9 +90,9 @@ extension _PlayerGestures on _PlayerPageState {
 
   void _showSeekRipple(int direction) {
     if (_seekRippleDirection != direction) {
-      _seekRippleSeconds = 10;
+      _seekRippleSeconds = _seekSeconds;
     } else {
-      _seekRippleSeconds += 10;
+      _seekRippleSeconds += _seekSeconds;
     }
     setState(() => _seekRippleDirection = direction);
     _seekRippleController.forward(from: 0);

--- a/lib/features/detail/presentation/pages/player_page.media.dart
+++ b/lib/features/detail/presentation/pages/player_page.media.dart
@@ -370,7 +370,7 @@ extension _PlayerMedia on _PlayerPageState {
       if (!isLoopback) {
         mergedHeaders.addAll(<String, String>{
           'User-Agent':
-              'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+              kSozoUserAgent,
           'Accept': '*/*',
           'Accept-Language': 'uz,ru;q=0.9,en;q=0.8',
         });

--- a/lib/features/detail/presentation/pages/player_page.panels.dart
+++ b/lib/features/detail/presentation/pages/player_page.panels.dart
@@ -345,7 +345,7 @@ extension _PlayerPanels on _PlayerPageState {
               _SettingsTile(
                 icon: Icons.bug_report_outlined,
                 label: 'player.diagnostics_logs'.tr(),
-                value: _isLive ? 'live' : '',
+                value: '',
                 onTap: () {
                   Navigator.of(sheetContext).pop();
                   LogViewerSheet.show(context);
@@ -616,6 +616,9 @@ extension _PlayerPanels on _PlayerPageState {
       child: Material(
         color: Colors.black.withValues(alpha: 0.92),
         child: SafeArea(
+          // The panel hugs the right edge, so the left cutout inset is not its
+          // to pay — honouring it just narrowed every row by ~44dp.
+          left: false,
           // Its own focus scope so _openPanel can hand the remote over and
           // _closePanel can hand it back — see [_tvPanelFocus].
           child: FocusScope(

--- a/lib/features/detail/presentation/pages/player_page.widgets.dart
+++ b/lib/features/detail/presentation/pages/player_page.widgets.dart
@@ -1,5 +1,12 @@
 part of 'player_page.dart';
 
+/// The controls sit directly on the frame, so a white-on-video label can land
+/// on a blown-out highlight and disappear. A tight drop shadow restores the
+/// edge without putting a container behind the control.
+const List<Shadow> _kControlShadow = <Shadow>[
+  Shadow(color: Color(0xB3000000), blurRadius: 6, offset: Offset(0, 1)),
+];
+
 class _LiveDot extends StatefulWidget {
   const _LiveDot();
 
@@ -120,14 +127,17 @@ class _ControlsScrim extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
+          // The bottom band has to cover the whole seek row *and* the action
+          // row beneath it, which reach ~30% up the screen in landscape — the
+          // old 0.82 stop left both of them sitting on bare video.
           colors: [
-            Color(0xCC000000),
-            Color(0x33000000),
+            Color(0xD9000000),
+            Color(0x4D000000),
             Color(0x00000000),
-            Color(0x33000000),
-            Color(0xCC000000),
+            Color(0x59000000),
+            Color(0xE6000000),
           ],
-          stops: [0.0, 0.18, 0.5, 0.82, 1.0],
+          stops: [0.0, 0.20, 0.46, 0.70, 1.0],
         ),
       ),
     );
@@ -261,7 +271,12 @@ class _IconButton extends StatelessWidget {
           child: SizedBox(
             width: 38,
             height: 38,
-            child: Icon(icon, color: color ?? Colors.white, size: 18),
+            child: Icon(
+              icon,
+              color: color ?? Colors.white,
+              size: 18,
+              shadows: _kControlShadow,
+            ),
           ),
         ),
       ),
@@ -329,7 +344,11 @@ class _LangPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
+    // Every one of its neighbours in the top bar draws a focus ring; without
+    // one this pill took D-pad focus with nothing to show for it.
+    return _tvRing(
+      radius: 20,
+      Material(
       color: Colors.black.withValues(alpha: 0.35),
       shape: const StadiumBorder(),
       child: InkWell(
@@ -359,6 +378,7 @@ class _LangPill extends StatelessWidget {
           ),
         ),
       ),
+      ),
     );
   }
 }
@@ -368,11 +388,17 @@ class _CenterIconButton extends StatelessWidget {
     required this.icon,
     required this.onTap,
     this.large = false,
+    this.busy = false,
     this.focusNode,
   });
   final IconData icon;
   final VoidCallback onTap;
   final bool large;
+
+  /// Draws the buffering ring on the button's own rim. Swapping the whole
+  /// cluster out for a spinner made the controls jump on every micro-stall and,
+  /// on TV, unmounted the node the remote was parked on.
+  final bool busy;
 
   /// Supplied only on TV, so the remote can be parked on this button whenever
   /// the overlay reappears. Null everywhere else — the InkWell then manages its
@@ -386,7 +412,9 @@ class _CenterIconButton extends StatelessWidget {
     return _tvRing(
       circle: true,
       Material(
-        color: Colors.black.withValues(alpha: 0.32),
+        // These buttons sit at the vertical centre, where the scrim is fully
+        // transparent — 32% black left a white glyph invisible on a bright shot.
+        color: Colors.black.withValues(alpha: 0.45),
         shape: const CircleBorder(),
         child: InkWell(
           onTap: onTap,
@@ -395,7 +423,24 @@ class _CenterIconButton extends StatelessWidget {
           child: SizedBox(
             width: size,
             height: size,
-            child: Icon(icon, color: Colors.white, size: iconSize),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Icon(
+                  icon,
+                  color: Colors.white,
+                  size: iconSize,
+                  shadows: _kControlShadow,
+                ),
+                if (busy)
+                  const Positioned.fill(
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.5,
+                      color: Colors.white70,
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ),
@@ -426,11 +471,11 @@ class _BottomTextButton extends StatelessWidget {
         onTap: enabled ? onTap : null,
         borderRadius: BorderRadius.circular(6),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(icon, color: color, size: 18),
+              Icon(icon, color: color, size: 18, shadows: _kControlShadow),
               const SizedBox(width: 4),
               Text(
                 label,
@@ -438,6 +483,7 @@ class _BottomTextButton extends StatelessWidget {
                   color: color,
                   fontSize: 12,
                   fontWeight: FontWeight.w600,
+                  shadows: _kControlShadow,
                 ),
               ),
             ],
@@ -558,9 +604,9 @@ class _QualityRow extends StatelessWidget {
                   color: AppColors.primary.withValues(alpha: 0.18),
                   borderRadius: BorderRadius.circular(4),
                 ),
-                child: const Text(
-                  'Default',
-                  style: TextStyle(
+                child: Text(
+                  'player.default'.tr(),
+                  style: const TextStyle(
                     color: AppColors.primaryLight,
                     fontSize: 10,
                     fontWeight: FontWeight.w700,
@@ -602,29 +648,37 @@ class _SettingsTile extends StatelessWidget {
               size: 20,
             ),
             const SizedBox(width: 14),
-            Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: disabled ? Colors.white54 : Colors.white,
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(width: 12),
+            // Both halves flex: a fixed-width label overflowed the row as soon
+            // as a translation ran long, and took the value with it.
             Expanded(
+              flex: 3,
               child: Text(
-                value,
+                label,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.right,
                 style: TextStyle(
-                  color: disabled ? Colors.white38 : Colors.white70,
-                  fontSize: 13,
+                  color: disabled ? Colors.white54 : Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
                 ),
               ),
             ),
+            if (value.isNotEmpty) ...[
+              const SizedBox(width: 12),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.right,
+                  style: TextStyle(
+                    color: disabled ? Colors.white38 : Colors.white70,
+                    fontSize: 13,
+                  ),
+                ),
+              ),
+            ],
             if (!disabled) ...[
               const SizedBox(width: 6),
               const Icon(

--- a/lib/features/detail/presentation/widgets/detail_cast_tab.dart
+++ b/lib/features/detail/presentation/widgets/detail_cast_tab.dart
@@ -58,11 +58,13 @@ class DetailCastTab extends StatelessWidget {
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
               itemCount: cast.length,
+              // 0.78 left the cell exactly as tall as its contents, so any
+              // two-line name or a bumped system font size overflowed it.
               gridDelegate: responsiveGridDelegate(
                 mobileCrossAxisCount: 3,
                 crossAxisSpacing: 8,
                 mainAxisSpacing: 14,
-                childAspectRatio: 0.78,
+                childAspectRatio: 0.70,
               ),
               itemBuilder: (_, i) => _CastGridCard(cast: cast[i]),
             ),
@@ -93,12 +95,16 @@ class _DirectorTile extends StatelessWidget {
             size: 18,
           ),
           const SizedBox(width: 10),
-          Text(
-            'movie.director'.tr(),
-            style: const TextStyle(
-              color: AppColors.textHint,
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
+          Flexible(
+            child: Text(
+              'movie.director'.tr(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: AppColors.textHint,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
           const SizedBox(width: 12),
@@ -146,16 +152,18 @@ class _CastGridCard extends StatelessWidget {
           children: [
             _CastAvatar(name: cast.name, imageUrl: cast.image),
             const SizedBox(height: 8),
-            Text(
-              cast.name.trim().isNotEmpty ? cast.name : '—',
-              maxLines: 2,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-                height: 1.2,
+            Flexible(
+              child: Text(
+                cast.name.trim().isNotEmpty ? cast.name : '—',
+                maxLines: 2,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  height: 1.2,
+                ),
               ),
             ),
             const SizedBox(height: 2),

--- a/lib/features/detail/presentation/widgets/detail_hero.dart
+++ b/lib/features/detail/presentation/widgets/detail_hero.dart
@@ -97,23 +97,37 @@ class _ThumbnailImage extends StatelessWidget {
         ),
       );
     }
-    return Image.network(
-      url!,
-      fit: BoxFit.cover,
-      errorBuilder: (_, _, _) => Container(
-        color: AppColors.surfaceVariant,
-        child: const Center(
-          child: Icon(
-            Icons.broken_image_outlined,
-            color: AppColors.textHint,
-            size: 64,
+    // Placeholder underneath rather than swapped in by loadingBuilder: the
+    // artwork used to cut in hard over a flat grey block, and the hard cut is
+    // the most visible thing on the page while it happens.
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        const ColoredBox(color: AppColors.surfaceVariant),
+        Image.network(
+          url!,
+          fit: BoxFit.cover,
+          errorBuilder: (_, _, _) => Container(
+            color: AppColors.surfaceVariant,
+            child: const Center(
+              child: Icon(
+                Icons.broken_image_outlined,
+                color: AppColors.textHint,
+                size: 64,
+              ),
+            ),
           ),
+          frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+            if (wasSynchronouslyLoaded) return child;
+            return AnimatedOpacity(
+              opacity: frame == null ? 0 : 1,
+              duration: const Duration(milliseconds: 240),
+              curve: Curves.easeOut,
+              child: child,
+            );
+          },
         ),
-      ),
-      loadingBuilder: (_, child, chunk) {
-        if (chunk == null) return child;
-        return Container(color: AppColors.surfaceVariant);
-      },
+      ],
     );
   }
 }

--- a/lib/features/detail/presentation/widgets/detail_info.dart
+++ b/lib/features/detail/presentation/widgets/detail_info.dart
@@ -157,7 +157,13 @@ class _MetaLine extends StatelessWidget {
         widgets.add(const _Dot());
       }
     }
-    return Row(children: widgets);
+    // Wrap, not Row: a long country or runtime string overflowed the line on
+    // narrow phones.
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      runSpacing: 4,
+      children: widgets,
+    );
   }
 }
 
@@ -197,8 +203,8 @@ class _GenresRow extends StatelessWidget {
             .map(
               (g) => Padding(
                 padding: const EdgeInsets.only(right: 6),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(6),
+                child: _Chip(
+                  label: g,
                   onTap: () {
                     final slug = _slugify(g);
                     if (slug.isEmpty) return;
@@ -207,7 +213,6 @@ class _GenresRow extends StatelessWidget {
                       extra: ViewAllEntity(type: 'genre', slug: slug),
                     );
                   },
-                  child: _Chip(label: g),
                 ),
               ),
             )
@@ -218,23 +223,30 @@ class _GenresRow extends StatelessWidget {
 }
 
 class _Chip extends StatelessWidget {
-  const _Chip({required this.label});
+  const _Chip({required this.label, required this.onTap});
   final String label;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceVariant,
+    // Material owns the fill so the ink lands on top of it; on the bare
+    // Container the splash painted under an opaque chip and was invisible.
+    return Material(
+      color: AppColors.surfaceVariant,
+      borderRadius: BorderRadius.circular(6),
+      child: InkWell(
+        onTap: onTap,
         borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        label,
-        style: const TextStyle(
-          color: AppColors.textSecondary,
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
         ),
       ),
     );
@@ -250,22 +262,63 @@ class _ExpandableDescription extends StatefulWidget {
 }
 
 class _ExpandableDescriptionState extends State<_ExpandableDescription> {
+  static const int _collapsedLines = 3;
+  static const TextStyle _style = TextStyle(
+    color: AppColors.textSecondary,
+    fontSize: 13,
+    height: 1.5,
+  );
+
   bool _expanded = false;
+
+  bool _overflows(BuildContext context, double maxWidth) {
+    final painter = TextPainter(
+      text: TextSpan(text: widget.text, style: _style),
+      maxLines: _collapsedLines,
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: maxWidth);
+    final exceeded = painter.didExceedMaxLines;
+    painter.dispose();
+    return exceeded;
+  }
 
   @override
   Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) => _build(context, constraints.maxWidth),
+    );
+  }
+
+  Widget _build(BuildContext context, double maxWidth) {
+    // Without this the synopsis was clamped to three lines with an ellipsis and
+    // nothing said it could be opened, so most of the plot was unreachable.
+    final clamped = maxWidth.isFinite && _overflows(context, maxWidth);
     final body = AnimatedSize(
       duration: const Duration(milliseconds: 180),
       alignment: Alignment.topCenter,
-      child: Text(
-        widget.text,
-        maxLines: _expanded ? null : 3,
-        overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
-        style: const TextStyle(
-          color: AppColors.textSecondary,
-          fontSize: 13,
-          height: 1.5,
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            widget.text,
+            maxLines: _expanded ? null : _collapsedLines,
+            overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+            style: _style,
+          ),
+          if (clamped || _expanded) ...[
+            const SizedBox(height: 4),
+            Text(
+              _expanded ? 'detail.show_less'.tr() : 'detail.show_more'.tr(),
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ],
       ),
     );
 

--- a/lib/features/detail/presentation/widgets/detail_more_sheet.dart
+++ b/lib/features/detail/presentation/widgets/detail_more_sheet.dart
@@ -29,6 +29,12 @@ Future<void> showDetailMoreSheet(
   return showModalBottomSheet<void>(
     context: context,
     backgroundColor: AppColors.surface,
+    // Without this the sheet is capped at 9/16 of the screen and the last rows
+    // (Find other sources, Open on TV, Share) fell off a short phone entirely.
+    isScrollControlled: true,
+    constraints: BoxConstraints(
+      maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+    ),
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
     ),
@@ -74,7 +80,10 @@ class _DetailMoreSheetState extends State<_DetailMoreSheet> {
   /// The TITLE is what travels. The two apps do not share a source registry, so
   /// this app's contentUrl means nothing to a TV without that provider — the TV
   /// resolves the title against its own sources.
+  bool _sendingToTv = false;
+
   Future<void> _playOnTv() async {
+    if (_sendingToTv) return;
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
     final service = getIt<RemoteControlService>();
@@ -83,6 +92,7 @@ class _DetailMoreSheetState extends State<_DetailMoreSheet> {
       SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
     );
 
+    setState(() => _sendingToTv = true);
     try {
       final devices = await service.devices();
       final online = devices.where((d) => d.online).toList();
@@ -116,6 +126,8 @@ class _DetailMoreSheetState extends State<_DetailMoreSheet> {
       say('remote.tv_offline'.tr());
     } catch (_) {
       say('remote.command_failed'.tr());
+    } finally {
+      if (mounted) setState(() => _sendingToTv = false);
     }
   }
 
@@ -126,17 +138,29 @@ class _DetailMoreSheetState extends State<_DetailMoreSheet> {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * 0.7,
+      ),
       builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            for (final device in devices)
-              ListTile(
-                leading: const Icon(Icons.tv_rounded, color: AppColors.textSecondary),
-                title: Text(device.name),
-                onTap: () => Navigator.of(sheetContext).pop(device),
-              ),
-          ],
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 12),
+              for (final device in devices)
+                ListTile(
+                  leading: const Icon(Icons.tv_rounded,
+                      color: AppColors.textSecondary),
+                  title: Text(
+                    device.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onTap: () => Navigator.of(sheetContext).pop(device),
+                ),
+            ],
+          ),
         ),
       ),
     );
@@ -195,77 +219,102 @@ class _DetailMoreSheetState extends State<_DetailMoreSheet> {
               ),
             ),
           ),
-          UserListToggle(
-            kind: UserListKind.watchLater,
-            entity: widget.entity,
-            sync: _listSync,
-            builder: (_, active, toggle) => _SheetRow(
-              icon: active
-                  ? Icons.watch_later_rounded
-                  : Icons.watch_later_outlined,
-              label: 'detail.watch_later'.tr(),
-              active: active,
-              onTap: toggle,
+          // The title stays pinned and only the actions scroll, so a short
+          // screen or a large system font never hides which title this is.
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  UserListToggle(
+                    kind: UserListKind.watchLater,
+                    entity: widget.entity,
+                    sync: _listSync,
+                    builder: (_, active, toggle) => _SheetRow(
+                      icon: active
+                          ? Icons.watch_later_rounded
+                          : Icons.watch_later_outlined,
+                      label: 'detail.watch_later'.tr(),
+                      active: active,
+                      onTap: toggle,
+                    ),
+                  ),
+                  UserListToggle(
+                    kind: UserListKind.watched,
+                    entity: widget.entity,
+                    sync: _listSync,
+                    builder: (_, active, toggle) => _SheetRow(
+                      icon: active
+                          ? Icons.visibility_rounded
+                          : Icons.visibility_outlined,
+                      label: 'detail.watched'.tr(),
+                      active: active,
+                      onTap: toggle,
+                    ),
+                  ),
+                  if (widget.showFollow)
+                    _SheetRow(
+                      icon: _following
+                          ? Icons.notifications_active_rounded
+                          : Icons.notifications_none_rounded,
+                      label: 'detail.follow_series'.tr(),
+                      active: _following,
+                      onTap: _toggleFollow,
+                    ),
+                  if (anilistReady) _AnilistRow(entity: widget.entity),
+                  const Divider(
+                    color: AppColors.divider,
+                    height: 17,
+                    indent: 18,
+                    endIndent: 18,
+                  ),
+                  _SheetRow(
+                    icon: Icons.travel_explore_rounded,
+                    label: 'detail.find_other_sources'.tr(),
+                    trailing: const Icon(
+                      Icons.chevron_right_rounded,
+                      color: AppColors.textHint,
+                      size: 20,
+                    ),
+                    onTap: () => _run(widget.onFindSources),
+                  ),
+                  _SheetRow(
+                    icon: Icons.cast_rounded,
+                    label: 'remote.open_on_tv'.tr(),
+                    // Looking up the linked TVs is a network round trip; without
+                    // a spinner the row looked dead until the picker appeared.
+                    trailing: _sendingToTv
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: AppColors.textSecondary,
+                            ),
+                          )
+                        : const Icon(
+                            Icons.chevron_right_rounded,
+                            color: AppColors.textHint,
+                            size: 20,
+                          ),
+                    onTap: _sendingToTv ? null : _playOnTv,
+                  ),
+                  _SheetRow(
+                    icon: Icons.ios_share_rounded,
+                    label: 'movie.share'.tr(),
+                    trailing: const Icon(
+                      Icons.chevron_right_rounded,
+                      color: AppColors.textHint,
+                      size: 20,
+                    ),
+                    onTap: () => _run(widget.onShare),
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
             ),
           ),
-          UserListToggle(
-            kind: UserListKind.watched,
-            entity: widget.entity,
-            sync: _listSync,
-            builder: (_, active, toggle) => _SheetRow(
-              icon: active ? Icons.visibility_rounded : Icons.visibility_outlined,
-              label: 'detail.watched'.tr(),
-              active: active,
-              onTap: toggle,
-            ),
-          ),
-          if (widget.showFollow)
-            _SheetRow(
-              icon: _following
-                  ? Icons.notifications_active_rounded
-                  : Icons.notifications_none_rounded,
-              label: 'detail.follow_series'.tr(),
-              active: _following,
-              onTap: _toggleFollow,
-            ),
-          if (anilistReady) _AnilistRow(entity: widget.entity),
-          const Divider(
-            color: AppColors.divider,
-            height: 17,
-            indent: 18,
-            endIndent: 18,
-          ),
-          _SheetRow(
-            icon: Icons.travel_explore_rounded,
-            label: 'detail.find_other_sources'.tr(),
-            trailing: const Icon(
-              Icons.chevron_right_rounded,
-              color: AppColors.textHint,
-              size: 20,
-            ),
-            onTap: () => _run(widget.onFindSources),
-          ),
-          _SheetRow(
-            icon: Icons.cast_rounded,
-            label: 'remote.open_on_tv'.tr(),
-            trailing: const Icon(
-              Icons.chevron_right_rounded,
-              color: AppColors.textHint,
-              size: 20,
-            ),
-            onTap: _playOnTv,
-          ),
-          _SheetRow(
-            icon: Icons.ios_share_rounded,
-            label: 'movie.share'.tr(),
-            trailing: const Icon(
-              Icons.chevron_right_rounded,
-              color: AppColors.textHint,
-              size: 20,
-            ),
-            onTap: () => _run(widget.onShare),
-          ),
-          const SizedBox(height: 8),
         ],
       ),
     );
@@ -407,52 +456,56 @@ class _SheetRow extends StatelessWidget {
 
   final IconData icon;
   final String label;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final bool active;
   final Color accent;
   final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 9),
-        child: Row(
-          children: [
-            Container(
-              width: 38,
-              height: 38,
-              decoration: BoxDecoration(
-                color: active
-                    ? accent.withValues(alpha: 0.16)
-                    : Colors.white.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(11),
-              ),
-              child: Icon(
-                icon,
-                size: 19,
-                color: active ? accent : AppColors.textPrimary,
-              ),
-            ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.textPrimary,
-                  fontSize: 14.5,
-                  fontWeight: FontWeight.w600,
+    return Opacity(
+      opacity: onTap == null ? 0.5 : 1,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 9),
+          child: Row(
+            children: [
+              Container(
+                width: 38,
+                height: 38,
+                decoration: BoxDecoration(
+                  color: active
+                      ? accent.withValues(alpha: 0.16)
+                      : Colors.white.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(11),
+                ),
+                child: Icon(
+                  icon,
+                  size: 19,
+                  color: active ? accent : AppColors.textPrimary,
                 ),
               ),
-            ),
-            trailing ??
-                (active
-                    ? Icon(Icons.check_rounded, size: 20, color: accent)
-                    : const SizedBox.shrink()),
-          ],
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  label,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 14.5,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              trailing ??
+                  (active
+                      ? Icon(Icons.check_rounded, size: 20, color: accent)
+                      : const SizedBox.shrink()),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/detail/presentation/widgets/detail_related.dart
+++ b/lib/features/detail/presentation/widgets/detail_related.dart
@@ -97,15 +97,18 @@ class _RelatedCard extends StatelessWidget {
               height: 1.25,
             ),
           ),
-          if (item.year != null)
-            Text(
-              item.year.toString(),
-              style: const TextStyle(
-                color: AppColors.textHint,
-                fontSize: 11,
-                height: 1.3,
-              ),
+          // Always laid out, even with no year: the poster is the Expanded
+          // child, so dropping this line made those cards' artwork taller than
+          // their neighbours' and the titles no longer lined up across a row.
+          Text(
+            item.year?.toString() ?? '',
+            maxLines: 1,
+            style: const TextStyle(
+              color: AppColors.textHint,
+              fontSize: 11,
+              height: 1.3,
             ),
+          ),
         ],
       ),
     );

--- a/lib/features/detail/presentation/widgets/detail_screenshots.dart
+++ b/lib/features/detail/presentation/widgets/detail_screenshots.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:soplay/core/system/responsive.dart';
 import 'package:soplay/core/theme/app_colors.dart';
@@ -13,21 +14,24 @@ class DetailScreenshotsSection extends StatelessWidget {
         .where((s) => s.thumb.isNotEmpty || s.full.isNotEmpty)
         .toList();
     if (valid.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 40),
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 40),
         child: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
+              const Icon(
                 Icons.image_outlined,
                 color: AppColors.textHint,
                 size: 48,
               ),
-              SizedBox(height: 12),
+              const SizedBox(height: 12),
               Text(
-                'No screenshots available',
-                style: TextStyle(color: AppColors.textSecondary, fontSize: 14),
+                'detail.no_screenshots'.tr(),
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 14,
+                ),
               ),
             ],
           ),

--- a/lib/features/detail/presentation/widgets/detail_skeleton.dart
+++ b/lib/features/detail/presentation/widgets/detail_skeleton.dart
@@ -7,6 +7,11 @@ class DetailSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final topPad = MediaQuery.paddingOf(context).top;
+    // Same formula the real hero uses in detail_page.dart. A fixed 420 meant
+    // the header visibly jumped by up to a hundred pixels the moment the page
+    // swapped from skeleton to content.
+    final heroHeight =
+        (MediaQuery.sizeOf(context).height * 0.55).clamp(320.0, 440.0);
     return Shimmer.fromColors(
       baseColor: const Color(0xFF1E1E1E),
       highlightColor: const Color(0xFF383838),
@@ -15,7 +20,7 @@ class DetailSkeleton extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _SkBox(width: double.infinity, height: 420 + topPad, radius: 0),
+            _SkBox(width: double.infinity, height: heroHeight + topPad, radius: 0),
             const _Pad(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -48,25 +53,24 @@ class DetailSkeleton extends StatelessWidget {
                   _SkBox(width: 200, height: 13, radius: 4),
                   SizedBox(height: 18),
                   _SkBox(width: double.infinity, height: 46, radius: 6),
-                  SizedBox(height: 10),
-                  _SkBox(width: double.infinity, height: 46, radius: 6),
-                  SizedBox(height: 18),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      _ActionSk(),
-                      _ActionSk(),
-                      _ActionSk(),
-                    ],
-                  ),
                 ],
               ),
             ),
-            const SizedBox(height: 28),
-            const _Pad(child: _SkBox(width: 80, height: 16, radius: 5)),
-            const SizedBox(height: 12),
-            _HorizontalSkRow(count: 6, itemWidth: 60, height: 60, circle: true),
-            const SizedBox(height: 100),
+            const SizedBox(height: 16),
+            const _Pad(
+              child: Row(
+                children: [
+                  _SkBox(width: 56, height: 14, radius: 4),
+                  SizedBox(width: 22),
+                  _SkBox(width: 44, height: 14, radius: 4),
+                  SizedBox(width: 22),
+                  _SkBox(width: 70, height: 14, radius: 4),
+                ],
+              ),
+            ),
+            const SizedBox(height: 18),
+            const _PosterGridSk(),
+            const SizedBox(height: 60),
           ],
         ),
       ),
@@ -102,60 +106,38 @@ class _Pad extends StatelessWidget {
   }
 }
 
-class _ActionSk extends StatelessWidget {
-  const _ActionSk();
+/// Stands in for the first tab, which is the three-across poster grid.
+class _PosterGridSk extends StatelessWidget {
+  const _PosterGridSk();
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: Container(width: 28, height: 28, color: Colors.white),
-        ),
-        const SizedBox(height: 6),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Container(width: 36, height: 10, color: Colors.white),
-        ),
-      ],
-    );
-  }
-}
-
-class _HorizontalSkRow extends StatelessWidget {
-  const _HorizontalSkRow({
-    required this.count,
-    required this.itemWidth,
-    required this.height,
-    this.circle = false,
-  });
-  final int count;
-  final double itemWidth;
-  final double height;
-  final bool circle;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: height,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        physics: const NeverScrollableScrollPhysics(),
-        itemCount: count,
-        itemBuilder: (_, _) => Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 5),
-          child: circle
-              ? ClipOval(
-                  child: Container(
-                    width: itemWidth,
-                    height: height,
-                    color: Colors.white,
-                  ),
-                )
-              : _SkBox(width: itemWidth, height: height, radius: 10),
-        ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Column(
+        children: [
+          for (var row = 0; row < 2; row++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Row(
+                children: [
+                  for (var col = 0; col < 3; col++) ...[
+                    if (col > 0) const SizedBox(width: 8),
+                    const Expanded(
+                      child: AspectRatio(
+                        aspectRatio: 0.66,
+                        child: _SkBox(
+                          width: double.infinity,
+                          height: double.infinity,
+                          radius: 8,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/features/download/presentation/pages/downloads_page.dart
+++ b/lib/features/download/presentation/pages/downloads_page.dart
@@ -150,72 +150,48 @@ class _DownloadsPageState extends State<DownloadsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final topPad = MediaQuery.paddingOf(context).top;
     final bottomPad = MediaQuery.paddingOf(context).bottom;
 
     return Scaffold(
       backgroundColor: AppColors.background,
       body: CustomScrollView(
         slivers: [
-          SliverToBoxAdapter(child: SizedBox(height: topPad + 8)),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  GestureDetector(
-                    onTap: () {
-                      if (context.canPop()) context.pop();
-                    },
-                    child: Container(
-                      width: 36,
-                      height: 36,
-                      decoration: const BoxDecoration(
-                        color: AppColors.surface,
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(
-                        Icons.arrow_back_ios_new_rounded,
-                        color: Colors.white,
-                        size: 16,
-                      ),
+          // Pinned: "Clear all" and the back button are the only controls on
+          // this screen, and a long queue scrolled them out of reach.
+          SliverAppBar(
+            pinned: true,
+            automaticallyImplyLeading: false,
+            backgroundColor: AppColors.background,
+            surfaceTintColor: Colors.transparent,
+            elevation: 0,
+            scrolledUnderElevation: 0,
+            titleSpacing: 16,
+            title: Row(
+              children: [
+                _CircleBackButton(
+                  onTap: () => context.canPop()
+                      ? context.pop()
+                      : context.go('/main'),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'navigation.downloads'.tr(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w800,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      'navigation.downloads'.tr(),
-                      style: const TextStyle(
-                        color: AppColors.textPrimary,
-                        fontSize: 22,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
+                ),
+                if (_items.isNotEmpty)
+                  _PillButton(
+                    label: 'downloads.clear_all'.tr(),
+                    onTap: _clearAll,
                   ),
-                  if (_items.isNotEmpty)
-                    GestureDetector(
-                      onTap: _clearAll,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 7,
-                        ),
-                        decoration: BoxDecoration(
-                          color: AppColors.surface,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          'downloads.clear_all'.tr(),
-                          style: const TextStyle(
-                            color: AppColors.primary,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+              ],
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 16)),
@@ -256,6 +232,63 @@ class _DownloadsPageState extends State<DownloadsPage> {
   }
 }
 
+class _CircleBackButton extends StatelessWidget {
+  const _CircleBackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(
+            Icons.arrow_back_ios_new_rounded,
+            color: AppColors.textPrimary,
+            size: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PillButton extends StatelessWidget {
+  const _PillButton({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(20),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _DownloadRow extends StatelessWidget {
   const _DownloadRow({
     required this.item,
@@ -269,10 +302,71 @@ class _DownloadRow extends StatelessWidget {
   final VoidCallback onRemove;
   final VoidCallback onRetry;
 
+  /// Swiping is the only way to drop a download on a phone, and nothing on
+  /// screen advertises it — a queued or failed row has no button at all.
+  Future<void> _showActions(BuildContext context) async {
+    final remove = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            Container(
+              width: 38,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.textSecondary.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                item.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(
+                Icons.delete_outline_rounded,
+                color: AppColors.error,
+              ),
+              title: Text(
+                'downloads.remove'.tr(),
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              onTap: () => Navigator.of(sheetCtx).pop(true),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (remove ?? false) onRemove();
+  }
+
   @override
   Widget build(BuildContext context) {
     final row = InkWell(
         onTap: item.status == DownloadStatus.completed ? onTap : null,
+        onLongPress: isDesktopPlatform ? null : () => _showActions(context),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
           child: Row(
@@ -462,16 +556,7 @@ class _DownloadRow extends StatelessWidget {
       key: ValueKey(item.id),
       direction: DismissDirection.endToStart,
       onDismissed: (_) => onRemove(),
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 24),
-        color: AppColors.primary.withValues(alpha: 0.15),
-        child: const Icon(
-          Icons.delete_outline_rounded,
-          color: AppColors.primary,
-          size: 22,
-        ),
-      ),
+      background: _SwipeToRemoveBackground(label: 'downloads.remove'.tr()),
       child: row,
     );
   }
@@ -481,6 +566,36 @@ class _DownloadRow extends StatelessWidget {
   String _mb(int bytes) {
     if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(0)} KB';
     return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}
+
+class _SwipeToRemoveBackground extends StatelessWidget {
+  const _SwipeToRemoveBackground({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      color: AppColors.error,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.delete_outline_rounded, color: Colors.white, size: 22),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/extensions/data/mangayomi_bridge.dart
+++ b/lib/features/extensions/data/mangayomi_bridge.dart
@@ -148,6 +148,7 @@ class MangayomiBridge {
     final sections = <Map<String, dynamic>>[];
     final banner = <Map<String, dynamic>>[];
     String? error;
+    runtime.dartFetch.clearBlock();
 
     // Popular and latest are independent calls, but the runtime serialises them
     // anyway (one shared JS context), so issue them in sequence and let one
@@ -187,6 +188,8 @@ class MangayomiBridge {
       if (!_isNotImplemented(e)) error ??= 'getLatestUpdates: $e';
     }
 
+    if (sections.isEmpty) error ??= runtime.dartFetch.takeBlock();
+
     return {
       'provider': src.providerId,
       'banner': banner,
@@ -224,16 +227,22 @@ class MangayomiBridge {
     if (src == null) {
       return {'provider': 'my:$id', 'items': const [], 'error': 'source not installed'};
     }
+    runtime.dartFetch.clearBlock();
     try {
       // Third arg is the filter list; every extension accepts an empty one.
       final raw = await runtime.call(id, 'search', args: [query, page, const []]);
       final items = _cards(raw, src);
+      // An extension parses whatever body it gets, so a blocked request comes
+      // back as an empty list and not as a throw. Empty because nothing matched
+      // and empty because the site never answered are worth telling apart.
+      final blocked = items.isEmpty ? runtime.dartFetch.takeBlock() : null;
       return {
         'provider': src.providerId,
         'items': items,
         'query': query,
         'page': page,
         'totalPages': _hasNext(raw) ? page + 1 : page,
+        'error': ?blocked,
       };
     } catch (e) {
       return {

--- a/lib/features/extensions/data/mangayomi_repo_store.dart
+++ b/lib/features/extensions/data/mangayomi_repo_store.dart
@@ -1,3 +1,4 @@
+import 'package:soplay/core/network/user_agent.dart';
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
@@ -39,7 +40,7 @@ class MangayomiRepoStore {
       responseType: ResponseType.plain,
       headers: const {
         'User-Agent':
-            'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36',
+            kSozoUserAgent,
       },
       // GitHub raw serves 404s for missing sibling indexes; treat any status as
       // a response so a missing anime_index.json isn't an exception.

--- a/lib/features/extensions/data/mangayomi_runtime.dart
+++ b/lib/features/extensions/data/mangayomi_runtime.dart
@@ -190,12 +190,31 @@ class MangayomiRuntime {
     _loaded[source.id] = source.version;
   }
 
+  /// Keys extensions conventionally read their host from.
+  ///
+  /// Mangayomi has no schema for this — each extension picks a name — so this
+  /// is the observed set, and an extension using another name still falls back
+  /// to whatever the user has set.
+  static const List<String> _domainKeys = [
+    'domain_url',
+    'overrideBaseUrl',
+    'baseUrl',
+    'preferred_domain',
+  ];
+
   Future<void> _seedPrefs(MangayomiSource source) async {
     final values = <String, dynamic>{};
-    // Defaults declared by the extension itself come first, then anything the
-    // user has overridden. Without the defaults, `preference.get('domain_url')`
-    // returns '' on a fresh install and sources that build their base url from
-    // it silently request the wrong host.
+    // The comment here used to promise defaults and the body never wrote any,
+    // so on a fresh install `preference.get('domain_url')` returned '' and the
+    // extension built a RELATIVE url. That reaches Dio with no host, throws
+    // "No host specified in URI", is caught, and comes back as zero results —
+    // indistinguishable from a title genuinely not being there.
+    if (source.baseUrl.isNotEmpty) {
+      for (final key in _domainKeys) {
+        values[key] = source.baseUrl;
+      }
+    }
+    // The user's own choices still win.
     values.addAll(store.prefs(source.id));
     await _controller!.evaluateJavascript(
       source: 'globalThis.__sozoPrefs = ${jsonEncode(values)};'

--- a/lib/features/extensions/data/mangayomi_runtime.dart
+++ b/lib/features/extensions/data/mangayomi_runtime.dart
@@ -7,6 +7,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'package:soplay/core/js/dart_fetch.dart';
 import 'package:soplay/core/js/js_log.dart';
+import 'package:soplay/core/js/js_timeouts.dart';
 import 'package:soplay/core/system/webview_env.dart';
 import 'package:soplay/features/extensions/data/mangayomi_repo_store.dart';
 import 'package:soplay/features/extensions/domain/entities/mangayomi_source.dart';
@@ -260,8 +261,12 @@ class MangayomiRuntime {
     JsLog.req(tag, method);
     await ensureReady();
 
+    // Bounded, and bounded INSIDE the lock. Every call queues behind _gate, so a
+    // single extension that never answers — a Cloudflare solve that never
+    // resolves, most often — used to hold every later call behind it forever,
+    // which is a screen left shimmering with nothing to time out.
     final result = await _locked(() async {
-      await _ensureExtension(source);
+      await _ensureExtension(source).timeout(kJsCallTimeout);
       final r = await _controller!.callAsyncJavaScript(
         functionBody: r'''
           const p = globalThis.__sozoProvider;
@@ -276,7 +281,7 @@ class MangayomiRuntime {
           return out === undefined ? null : JSON.stringify(out);
         ''',
         arguments: {'fnName': method, 'fnArgs': args},
-      );
+      ).timeout(kJsCallTimeout);
       await _flushPrefs(source);
       return r;
     });

--- a/lib/features/history/presentation/pages/history_page.dart
+++ b/lib/features/history/presentation/pages/history_page.dart
@@ -108,7 +108,6 @@ class _HistoryPageState extends State<HistoryPage> {
 
   @override
   Widget build(BuildContext context) {
-    final topPad = MediaQuery.paddingOf(context).top;
     final bottomPad = MediaQuery.paddingOf(context).bottom;
 
     return Scaffold(
@@ -116,67 +115,42 @@ class _HistoryPageState extends State<HistoryPage> {
       body: CustomScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
-          SliverToBoxAdapter(child: SizedBox(height: topPad + 8)),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  GestureDetector(
-                    onTap: () {
-                      if (context.canPop()) {
-                        context.pop();
-                      }
-                    },
-                    child: Container(
-                      width: 36,
-                      height: 36,
-                      decoration: BoxDecoration(
-                        color: AppColors.surface,
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(
-                        Icons.arrow_back_ios_new_rounded,
-                        color: Colors.white,
-                        size: 16,
-                      ),
+          // Pinned: "Clear all" and the back button are the only controls on
+          // this screen, and a long history scrolled them out of reach.
+          SliverAppBar(
+            pinned: true,
+            automaticallyImplyLeading: false,
+            backgroundColor: AppColors.background,
+            surfaceTintColor: Colors.transparent,
+            elevation: 0,
+            scrolledUnderElevation: 0,
+            titleSpacing: 16,
+            title: Row(
+              children: [
+                _CircleBackButton(
+                  onTap: () => context.canPop()
+                      ? context.pop()
+                      : context.go('/main'),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'profile.watch_history'.tr(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w800,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      'profile.watch_history'.tr(),
-                      style: const TextStyle(
-                        color: AppColors.textPrimary,
-                        fontSize: 22,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
+                ),
+                if (_items.isNotEmpty)
+                  _PillButton(
+                    label: 'history.clear_all'.tr(),
+                    onTap: _clearHistory,
                   ),
-                  if (_items.isNotEmpty)
-                    GestureDetector(
-                      onTap: _clearHistory,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 7,
-                        ),
-                        decoration: BoxDecoration(
-                          color: AppColors.surface,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          'history.clear_all'.tr(),
-                          style: const TextStyle(
-                            color: AppColors.primary,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+              ],
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 16)),
@@ -216,6 +190,63 @@ class _HistoryPageState extends State<HistoryPage> {
   }
 }
 
+class _CircleBackButton extends StatelessWidget {
+  const _CircleBackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(
+            Icons.arrow_back_ios_new_rounded,
+            color: AppColors.textPrimary,
+            size: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PillButton extends StatelessWidget {
+  const _PillButton({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(20),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _HistoryRow extends StatelessWidget {
   const _HistoryRow({
     required this.item,
@@ -227,10 +258,71 @@ class _HistoryRow extends StatelessWidget {
   final VoidCallback onTap;
   final VoidCallback onDismissed;
 
+  /// Swiping is the only way to delete a row on a phone, and nothing on screen
+  /// advertises it. Long-press offers the same action out in the open.
+  Future<void> _showActions(BuildContext context) async {
+    final remove = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            Container(
+              width: 38,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.textSecondary.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                item.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(
+                Icons.delete_outline_rounded,
+                color: AppColors.error,
+              ),
+              title: Text(
+                'history.remove'.tr(),
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              onTap: () => Navigator.of(sheetCtx).pop(true),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (remove ?? false) onDismissed();
+  }
+
   @override
   Widget build(BuildContext context) {
     final row = InkWell(
         onTap: onTap,
+        onLongPress: isDesktopPlatform ? null : () => _showActions(context),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
           child: Row(
@@ -321,7 +413,7 @@ class _HistoryRow extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      _timeAgo(item.watchedAt),
+                      _watchedAgo(context, item.watchedAt),
                       style: const TextStyle(
                         color: AppColors.textHint,
                         fontSize: 10,
@@ -368,16 +460,7 @@ class _HistoryRow extends StatelessWidget {
       key: ValueKey(item.storageKey),
       direction: DismissDirection.endToStart,
       onDismissed: (_) => onDismissed(),
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 24),
-        color: AppColors.primary.withValues(alpha: 0.15),
-        child: const Icon(
-          Icons.delete_outline_rounded,
-          color: AppColors.primary,
-          size: 22,
-        ),
-      ),
+      background: _SwipeToRemoveBackground(label: 'history.remove'.tr()),
       child: row,
     );
   }
@@ -397,16 +480,46 @@ class _HistoryRow extends StatelessWidget {
     return '${two(m)}:${two(s)}';
   }
 
-  String _timeAgo(int ms) {
-    final diff = DateTime.now().millisecondsSinceEpoch - ms;
-    final minutes = diff ~/ 60000;
-    if (minutes < 1) return 'Just now';
-    if (minutes < 60) return '${minutes}m ago';
-    final hours = minutes ~/ 60;
-    if (hours < 24) return '${hours}h ago';
-    final days = hours ~/ 24;
-    if (days < 7) return '${days}d ago';
-    return '${days ~/ 7}w ago';
+  /// Same shape as the notifications list, which is the app's only other
+  /// timestamped feed — the two used to disagree, in English only.
+  String _watchedAgo(BuildContext context, int ms) {
+    final at = DateTime.fromMillisecondsSinceEpoch(ms);
+    final diff = DateTime.now().difference(at);
+    if (diff.inMinutes < 1) return 'time.now'.tr();
+    if (diff.inHours < 1) return 'time.minutes'.tr(args: ['${diff.inMinutes}']);
+    if (diff.inDays < 1) return 'time.hours'.tr(args: ['${diff.inHours}']);
+    if (diff.inDays < 7) return 'time.days'.tr(args: ['${diff.inDays}']);
+    return DateFormat.yMMMd(context.locale.toString()).format(at);
+  }
+}
+
+class _SwipeToRemoveBackground extends StatelessWidget {
+  const _SwipeToRemoveBackground({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      color: AppColors.error,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.delete_outline_rounded, color: Colors.white, size: 22),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/home/presentation/widgets/backend_outage_banner.dart
+++ b/lib/features/home/presentation/widgets/backend_outage_banner.dart
@@ -72,8 +72,8 @@ class _BackendOutageBannerState extends State<BackendOutageBanner> {
                 if (localCount > 0)
                   TextButton(
                     style: TextButton.styleFrom(
-                      minimumSize: const Size(0, 30),
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      minimumSize: const Size(0, 44),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
                       foregroundColor: Colors.orange,
                     ),
                     onPressed: () => openProviderPicker(
@@ -89,8 +89,8 @@ class _BackendOutageBannerState extends State<BackendOutageBanner> {
                 else
                   TextButton(
                     style: TextButton.styleFrom(
-                      minimumSize: const Size(0, 30),
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      minimumSize: const Size(0, 44),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
                       foregroundColor: Colors.orange,
                     ),
                     onPressed: () =>
@@ -103,7 +103,13 @@ class _BackendOutageBannerState extends State<BackendOutageBanner> {
                   ),
                 IconButton(
                   visualDensity: VisualDensity.compact,
-                  constraints: const BoxConstraints(),
+                  // Was an unconstrained 4dp pad around a 15dp icon: a ~23dp
+                  // target for the only way to get rid of this banner. 48 and
+                  // not 44 because compact density takes 4 back off.
+                  constraints: const BoxConstraints(
+                    minWidth: 48,
+                    minHeight: 48,
+                  ),
                   padding: const EdgeInsets.all(4),
                   icon: const Icon(Icons.close_rounded,
                       size: 15, color: Colors.orange),

--- a/lib/features/home/presentation/widgets/genre_card.dart
+++ b/lib/features/home/presentation/widgets/genre_card.dart
@@ -1,12 +1,10 @@
-
-
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/system/responsive.dart';
-import '../../../../core/theme/app_colors.dart';
 import '../../../search/domain/entities/genre_entity.dart';
 import '../../domain/entities/view_all.dart';
+import 'home_shared_widgets.dart';
 
 class GenreCard extends StatelessWidget {
   const GenreCard({super.key, required this.genre});
@@ -40,15 +38,11 @@ class GenreCard extends StatelessWidget {
             child: Stack(
               fit: StackFit.expand,
               children: [
-                genre.image.isNotEmpty
-                    ? Image.network(
-                  genre.image,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => ColoredBox(
-                    color: AppColors.surfaceVariant,
-                  ),
-                )
-                    : ColoredBox(color: AppColors.surfaceVariant),
+                HomeNetworkImage(
+                  url: genre.image,
+                  borderRadius: BorderRadius.zero,
+                  placeholderIcon: Icons.category_outlined,
+                ),
                 DecoratedBox(
                   decoration: BoxDecoration(
                     gradient: LinearGradient(

--- a/lib/features/home/presentation/widgets/home_banner.dart
+++ b/lib/features/home/presentation/widgets/home_banner.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -54,6 +55,10 @@ class _HomeBannerState extends State<HomeBanner> {
   void _startTimer() {
     _timer = Timer.periodic(const Duration(seconds: 5), (_) {
       if (!mounted || widget.slides.length < 2) return;
+      if (!_ctrl.hasClients) return;
+      // Auto-advancing on top of a drag or a fling yanked the slide out from
+      // under the finger; skip this tick and take the next one instead.
+      if (_ctrl.position.isScrollingNotifier.value) return;
       final next = (_page + 1) % widget.slides.length;
       _ctrl.animateToPage(
         next,
@@ -93,7 +98,9 @@ class _HomeBannerState extends State<HomeBanner> {
   Widget build(BuildContext context) {
     if (widget.slides.isEmpty) {
       return widget.showSkeleton
-          ? HomeBannerSkeleton(topPadding: widget.topPadding)
+          ? ShimmerWrapper(
+              child: HomeBannerSkeleton(topPadding: widget.topPadding),
+            )
           : const SizedBox.shrink();
     }
 
@@ -106,13 +113,8 @@ class _HomeBannerState extends State<HomeBanner> {
       );
     }
 
-    final height = (MediaQuery.of(context).size.height * 0.63).clamp(
-      440.0,
-      480.0,
-    );
-
     return SizedBox(
-      height: height,
+      height: mobileHeroHeight(context),
       child: Stack(
         children: [
           PageView.builder(
@@ -249,9 +251,10 @@ class _BannerSlide extends StatelessWidget {
         CachedNetworkImage(
           imageUrl: banner.imageUrl,
           fit: BoxFit.cover,
-          errorWidget: (_, _, _) => const ColoredBox(
-            color: AppColors.surfaceVariant,
-          ),
+          placeholder: (_, _) =>
+              const HomeImagePlaceholder(icon: Icons.image_outlined),
+          errorWidget: (_, _, _) =>
+              const HomeImagePlaceholder(icon: Icons.image_not_supported_outlined),
         ),
         const _SlideOverlays(),
         Positioned(
@@ -339,16 +342,21 @@ class _MovieInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final meta = movieMetaLabels(movie);
+    final description = movieDescription(movie);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (meta.isNotEmpty)
+        // Gaps ride with their content: unconditional ones left a hole above
+        // the title on slides with no chips, so titles sat at different
+        // heights as the hero paged.
+        if (meta.isNotEmpty) ...[
           Wrap(
             spacing: 6,
             runSpacing: 6,
             children: meta.take(4).map((m) => _MetaChip(label: m)).toList(),
           ),
-        const SizedBox(height: 10),
+          const SizedBox(height: 10),
+        ],
         Text(
           movieTitle(movie),
           maxLines: 1,
@@ -368,19 +376,21 @@ class _MovieInfo extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 8),
-        Text(
-          movieDescription(movie),
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            height: 1.08,
-            letterSpacing: -0.3,
+        if (description.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Text(
+            description,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              height: 1.08,
+              letterSpacing: -0.3,
+            ),
           ),
-        ),
+        ],
       ],
     );
   }
@@ -464,8 +474,8 @@ class _MetaChip extends StatelessWidget {
 
 // ─────────────────────────────────────────────────────────────────────────
 // Desktop banner — Sozo-Desktop / Akuse style: rounded 450px card, blurred
-// Ken Burns backdrop, crisp right poster, Play + More Info buttons, dot
-// indicators. Both movie and CMS-banner slides are supported.
+// Ken Burns backdrop, crisp right poster, Play + More Info buttons. Both
+// movie and CMS-banner slides are supported.
 // ─────────────────────────────────────────────────────────────────────────
 
 const double _kDesktopBannerHeight = 450.0;
@@ -793,14 +803,14 @@ class _DesktopSlideState extends State<_DesktopSlide>
             Row(
               children: [
                 _BannerButton(
-                  label: 'Play',
+                  label: 'player.play'.tr(),
                   icon: Icons.play_arrow_rounded,
                   primary: true,
                   onTap: () => _openMovie(context, movie),
                 ),
                 const SizedBox(width: 10),
                 _BannerButton(
-                  label: 'More info',
+                  label: 'home.more_info'.tr(),
                   icon: Icons.info_outline_rounded,
                   primary: false,
                   onTap: () => _openMovie(context, movie),
@@ -844,7 +854,7 @@ class _DesktopSlideState extends State<_DesktopSlide>
             ],
             const SizedBox(height: 18),
             _BannerButton(
-              label: 'More info',
+              label: 'home.more_info'.tr(),
               icon: Icons.open_in_new_rounded,
               primary: true,
               onTap: () => widget.onBannerTap(banner),
@@ -1008,6 +1018,12 @@ class _BannerButtonState extends State<_BannerButton> {
   }
 }
 
+/// Height of the mobile hero. The skeleton MUST use the same number: it used
+/// to clamp to 460–580 against the real 440–480, so the whole feed jumped by up
+/// to 100px the moment the banners arrived.
+double mobileHeroHeight(BuildContext context) =>
+    (MediaQuery.sizeOf(context).height * 0.63).clamp(440.0, 480.0);
+
 class HomeBannerSkeleton extends StatelessWidget {
   const HomeBannerSkeleton({super.key, required this.topPadding});
 
@@ -1015,14 +1031,23 @@ class HomeBannerSkeleton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final height = (MediaQuery.of(context).size.height * 0.63).clamp(
-      460.0,
-      580.0,
-    );
-    return SizedBox(
-      height: height,
+    if (isDesktopPlatform) {
+      return Padding(
+        padding: EdgeInsets.fromLTRB(24, topPadding + 72, 24, 22),
+        child: const HomeSkeletonBox(
+          width: double.infinity,
+          height: _kDesktopBannerHeight,
+          radius: _kDesktopBannerRadius,
+        ),
+      );
+    }
+
+    // Was a box painted in the page background colour — indistinguishable from
+    // an empty screen, so the load read as "nothing is happening".
+    return HomeSkeletonBox(
       width: double.infinity,
-      child: const ColoredBox(color: AppColors.background),
+      height: mobileHeroHeight(context),
+      radius: 0,
     );
   }
 }

--- a/lib/features/home/presentation/widgets/home_content.dart
+++ b/lib/features/home/presentation/widgets/home_content.dart
@@ -21,6 +21,7 @@ import 'package:soplay/features/home/presentation/bloc/home/home_event.dart';
 import 'package:soplay/features/home/presentation/widgets/home_banner.dart';
 import 'package:soplay/features/home/presentation/widgets/home_history_section.dart';
 import 'package:soplay/features/home/presentation/widgets/home_movie_section.dart';
+import 'package:soplay/features/home/presentation/widgets/home_state_views.dart';
 import 'package:soplay/features/search/domain/entities/genre_entity.dart';
 
 import '../bloc/home/home_state.dart';
@@ -171,6 +172,27 @@ class _HomeContentBody extends StatelessWidget {
                   ),
                 ),
           ];
+
+          final isEmpty = !showHero &&
+              historyItems.isEmpty &&
+              state.genres.isEmpty &&
+              sectionSlivers.isEmpty;
+          if (isEmpty) {
+            return CustomScrollView(
+              controller: scrollController,
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Padding(
+                    padding: EdgeInsets.only(top: topPad + 56),
+                    child: HomeEmptyView(onRefresh: onRefresh),
+                  ),
+                ),
+              ],
+            );
+          }
+
           // Sponsor/CMS banner strip mid-feed (home_middle placement). It
           // self-collapses when the placement has no active banners, and its
           // view/click tracking is guest-safe (no auth required).
@@ -246,7 +268,7 @@ class _GenreSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(17, 18, 16, 12),
+            padding: const EdgeInsets.fromLTRB(17, 18, 16, 14),
             child: Text(
               "home.genres".tr(),
               style: const TextStyle(
@@ -261,6 +283,8 @@ class _GenreSection extends StatelessWidget {
             height: isDesktopPlatform ? 90 : 72,
             child: ListView.builder(
               scrollDirection: Axis.horizontal,
+              // Don't clip the hover scale on desktop, as MovieSection does.
+              clipBehavior: isDesktopPlatform ? Clip.none : Clip.hardEdge,
               padding: const EdgeInsets.symmetric(horizontal: 12),
               itemCount: genres.length,
               itemBuilder: (_, i) => GenreCard(genre: genres[i]),

--- a/lib/features/home/presentation/widgets/home_downloads_section.dart
+++ b/lib/features/home/presentation/widgets/home_downloads_section.dart
@@ -53,11 +53,12 @@ class _DownloadsSectionState extends State<DownloadsSection> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(17, 18, 16, 14),
-            child: InkWell(
-              onTap: () => context.push('/downloads'),
-              borderRadius: BorderRadius.circular(8),
+          // Padding inside the InkWell — outside it the tap target was only as
+          // tall as the title text.
+          InkWell(
+            onTap: () => context.push('/downloads'),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(17, 18, 20, 14),
               child: Row(
                 children: [
                   const Icon(

--- a/lib/features/home/presentation/widgets/home_history_section.dart
+++ b/lib/features/home/presentation/widgets/home_history_section.dart
@@ -35,59 +35,55 @@ class HistorySection extends StatelessWidget {
     final filtered = _continueWatching();
     if (filtered.isEmpty) return const SizedBox.shrink();
     final visible = filtered.length > 20 ? filtered.sublist(0, 20) : filtered;
+    final showViewAll =
+        filtered.length > visible.length || filtered.length >= 3;
     return Padding(
       padding: const EdgeInsets.only(bottom: 4),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(17, 18, 12, 14),
-            child: Row(
-              children: [
-                const Icon(
-                  Icons.history_rounded,
-                  color: AppColors.textSecondary,
-                  size: 18,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'home.continue_watching'.tr(),
-                    style: const TextStyle(
-                      color: AppColors.textPrimary,
-                      fontSize: 17,
-                      fontWeight: FontWeight.w800,
-                      height: 1.1,
-                    ),
+          // Whole header strip is the target, like every other rail: the old
+          // "View all" TextButton was a ~26dp tap target squeezed into the row.
+          InkWell(
+            onTap: showViewAll ? () => context.push('/history') : null,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(17, 18, 20, 14),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.history_rounded,
+                    color: AppColors.textSecondary,
+                    size: 18,
                   ),
-                ),
-                if (filtered.length > visible.length || filtered.length >= 3)
-                  TextButton(
-                    onPressed: () => context.push('/history'),
-                    style: TextButton.styleFrom(
-                      foregroundColor: AppColors.textSecondary,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 4,
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'home.continue_watching'.tr(),
+                      style: const TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 17,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
                       ),
-                      minimumSize: const Size(0, 0),
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          'home.view_all'.tr(),
-                          style: const TextStyle(
-                            fontSize: 12.5,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        const Icon(Icons.chevron_right_rounded, size: 18),
-                      ],
                     ),
                   ),
-              ],
+                  if (showViewAll) ...[
+                    Text(
+                      'home.view_all'.tr(),
+                      style: const TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const Icon(
+                      Icons.chevron_right_rounded,
+                      color: AppColors.textSecondary,
+                      size: 18,
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
           SizedBox(
@@ -205,6 +201,10 @@ class _HistoryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final label = item.episodeLabel?.trim();
+    final episodeLabel = (item.isSerial && label != null && label.isNotEmpty)
+        ? label
+        : null;
     return HoverTap(
       onTap: () => _openDetail(context),
       onLongPress: () => _showActions(context),
@@ -309,30 +309,37 @@ class _HistoryCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 6),
-              Text(
-                item.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.textPrimary,
-                  fontSize: 11.5,
-                  fontWeight: FontWeight.w600,
-                  height: 1.25,
-                ),
-              ),
-              if (item.isSerial &&
-                  item.episodeLabel != null &&
-                  item.episodeLabel!.trim().isNotEmpty)
-                Text(
-                  item.episodeLabel!,
+              FixedTextLines(
+                fontSize: 11.5,
+                lineHeight: 1.25,
+                child: Text(
+                  item.title,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 10,
-                    height: 1.3,
+                    color: AppColors.textPrimary,
+                    fontSize: 11.5,
+                    fontWeight: FontWeight.w600,
+                    height: 1.25,
                   ),
                 ),
+              ),
+              FixedTextLines(
+                fontSize: 10,
+                lineHeight: 1.3,
+                child: episodeLabel == null
+                    ? null
+                    : Text(
+                        episodeLabel,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 10,
+                          height: 1.3,
+                        ),
+                      ),
+              ),
             ],
           ),
         ),

--- a/lib/features/home/presentation/widgets/home_movie_section.dart
+++ b/lib/features/home/presentation/widgets/home_movie_section.dart
@@ -33,28 +33,23 @@ class MovieSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(13, 18, 16, 14),
-            child: InkWell(
-              borderRadius: BorderRadius.only(
-                topRight: Radius.circular(8),
-                bottomRight: Radius.circular(8),
-              ),
-              onTap: () {
-                if (onSeeAll != null) {
-                  onSeeAll!();
-                  return;
-                }
-                context.push(
-                  '/view-all',
-                  extra: ViewAllEntity(type: type, slug: slug, name: title),
-                );
-              },
+          // The padding is INSIDE the InkWell: outside it, the tappable strip
+          // was only as tall as the title text (~19dp).
+          InkWell(
+            onTap: () {
+              if (onSeeAll != null) {
+                onSeeAll!();
+                return;
+              }
+              context.push(
+                '/view-all',
+                extra: ViewAllEntity(type: type, slug: slug, name: title),
+              );
+            },
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(17, 18, 20, 14),
               child: Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  SizedBox(width: 4),
                   if (isHighlighted) ...[
                     Container(
                       width: 3,
@@ -84,7 +79,6 @@ class MovieSection extends StatelessWidget {
                     color: AppColors.textHint,
                     size: 22,
                   ),
-                  SizedBox(width: 4),
                 ],
               ),
             ),
@@ -223,43 +217,54 @@ class _MovieCardState extends State<_MovieCard> {
           children: [
             cover,
             SizedBox(height: desktop ? 10 : 6),
-            Text(
-              movieTitle(movie),
-              maxLines: desktop ? 2 : 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: desktop ? 15 : 11.5,
-                fontWeight: desktop ? FontWeight.w800 : FontWeight.w600,
-                height: desktop ? 1.3 : 1.25,
+            FixedTextLines(
+              fontSize: desktop ? 15 : 11.5,
+              lineHeight: desktop ? 1.3 : 1.25,
+              lines: desktop ? 2 : 1,
+              child: Text(
+                movieTitle(movie),
+                maxLines: desktop ? 2 : 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: desktop ? 15 : 11.5,
+                  fontWeight: desktop ? FontWeight.w800 : FontWeight.w600,
+                  height: desktop ? 1.3 : 1.25,
+                ),
               ),
             ),
-            if (movie.year != null) ...[
-              SizedBox(height: desktop ? 6 : 0),
-              Row(
-                children: [
-                  if (desktop) ...[
-                    const Icon(
-                      Icons.calendar_today_rounded,
-                      size: 12,
-                      color: AppColors.textHint,
+            SizedBox(height: desktop ? 6 : 0),
+            FixedTextLines(
+              fontSize: desktop ? 12.5 : 10,
+              lineHeight: 1.3,
+              child: movie.year == null
+                  ? null
+                  : Row(
+                      children: [
+                        if (desktop) ...[
+                          const Icon(
+                            Icons.calendar_today_rounded,
+                            size: 12,
+                            color: AppColors.textHint,
+                          ),
+                          const SizedBox(width: 5),
+                        ],
+                        Text(
+                          movie.year.toString(),
+                          style: TextStyle(
+                            color: desktop
+                                ? AppColors.textHint
+                                : AppColors.textSecondary,
+                            fontSize: desktop ? 12.5 : 10,
+                            fontWeight: desktop
+                                ? FontWeight.w600
+                                : FontWeight.w400,
+                            height: 1.3,
+                          ),
+                        ),
+                      ],
                     ),
-                    const SizedBox(width: 5),
-                  ],
-                  Text(
-                    movie.year.toString(),
-                    style: TextStyle(
-                      color: desktop
-                          ? AppColors.textHint
-                          : AppColors.textSecondary,
-                      fontSize: desktop ? 12.5 : 10,
-                      fontWeight: desktop ? FontWeight.w600 : FontWeight.w400,
-                      height: 1.3,
-                    ),
-                  ),
-                ],
-              ),
-            ],
+            ),
           ],
         ),
       ),

--- a/lib/features/home/presentation/widgets/home_shared_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_shared_widgets.dart
@@ -1,3 +1,4 @@
+import 'package:soplay/core/network/user_agent.dart';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -9,9 +10,11 @@ class ShimmerWrapper extends StatelessWidget {
   const ShimmerWrapper({super.key, required this.child});
   final Widget child;
 
-  // Subtle sweep tuned for the dark surface — low contrast, slow period.
-  static const _base = Color(0xFF202020);
-  static const _highlight = Color(0xFF2B2B2B);
+  // Subtle, but not invisible: eleven levels of separation on a dark panel read
+  // as a frozen screen rather than as loading, which is the one thing a skeleton
+  // exists to avoid.
+  static const _base = Color(0xFF1E1E1E);
+  static const _highlight = Color(0xFF333333);
 
   @override
   Widget build(BuildContext context) => Shimmer.fromColors(
@@ -44,9 +47,10 @@ class HomeNetworkImage extends StatelessWidget {
     if (uri == null || !uri.hasScheme || uri.host.isEmpty) return null;
     return {
       'Referer': '${uri.scheme}://${uri.host}/',
-      'User-Agent':
-          'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) '
-              'Chrome/124.0 Mobile Safari/537.36',
+      // Must be the app's one agent: a cf_clearance cookie is bound to the exact
+      // agent that earned it, so a poster asking under a different one is
+      // challenged and never loads.
+      'User-Agent': kSozoUserAgent,
     };
   }
 

--- a/lib/features/home/presentation/widgets/home_shared_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_shared_widgets.dart
@@ -120,8 +120,41 @@ class HomeImagePlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: AppColors.surfaceVariant,
-      child: Center(child: Icon(icon, color: AppColors.textHint, size: 28)),
+      child: Center(
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Icon(icon, color: AppColors.textHint, size: 28),
+        ),
+      ),
     );
+  }
+}
+
+/// Reserves the vertical space of [lines] text lines whether or not [child]
+/// has anything to draw.
+///
+/// Poster rails size their cover with an [Expanded], so a card whose caption
+/// happens to be one line shorter than its neighbour's silently gets a TALLER
+/// poster — the row ends up ragged. Reserving the caption box keeps every
+/// poster in a rail identical, and scales with the user's text size.
+class FixedTextLines extends StatelessWidget {
+  const FixedTextLines({
+    super.key,
+    required this.fontSize,
+    required this.lineHeight,
+    this.lines = 1,
+    this.child,
+  });
+
+  final double fontSize;
+  final double lineHeight;
+  final int lines;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scaled = MediaQuery.textScalerOf(context).scale(fontSize);
+    return SizedBox(height: scaled * lineHeight * lines, child: child);
   }
 }
 

--- a/lib/features/home/presentation/widgets/home_state_views.dart
+++ b/lib/features/home/presentation/widgets/home_state_views.dart
@@ -25,22 +25,27 @@ class HomeSkeleton extends StatelessWidget {
         physics: const NeverScrollableScrollPhysics(),
         slivers: [
           SliverToBoxAdapter(child: HomeBannerSkeleton(topPadding: topPad)),
+          // Geometry mirrors the loaded sections exactly (see MovieSection and
+          // _GenreSection); when it did not, every rail nudged sideways and
+          // downwards the moment the data landed.
           SliverToBoxAdapter(
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 18, 16, 12),
+              padding: const EdgeInsets.only(bottom: 4),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const HomeSkeletonBox(width: 80, height: 15, radius: 4),
-                  const SizedBox(height: 12),
+                  const Padding(
+                    padding: EdgeInsets.fromLTRB(17, 18, 16, 14),
+                    child: HomeSkeletonBox(width: 80, height: 19, radius: 4),
+                  ),
                   SizedBox(
                     height: 72,
                     child: ListView.builder(
                       scrollDirection: Axis.horizontal,
-                      padding: EdgeInsets.zero,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
                       itemCount: 6,
                       itemBuilder: (_, _) => const Padding(
-                        padding: EdgeInsets.only(right: 8),
+                        padding: EdgeInsets.symmetric(horizontal: 4),
                         child: HomeSkeletonBox(
                           width: 110,
                           height: 72,
@@ -56,30 +61,33 @@ class HomeSkeleton extends StatelessWidget {
           for (int i = 0; i < 3; i++) ...[
             SliverToBoxAdapter(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 18, 16, 10),
+                padding: const EdgeInsets.fromLTRB(17, 18, 20, 14),
                 child: Row(
                   children: [
                     HomeSkeletonBox(
                       width: 100 + (i * 24).toDouble(),
-                      height: 15,
+                      height: 19,
                       radius: 4,
                     ),
                     const Spacer(),
-                    const HomeSkeletonBox(width: 18, height: 15, radius: 4),
+                    const HomeSkeletonBox(width: 22, height: 19, radius: 4),
                   ],
                 ),
               ),
             ),
             SliverToBoxAdapter(
-              child: SizedBox(
-                height: 195,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  itemCount: 6,
-                  itemBuilder: (_, _) => const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 4),
-                    child: _SkeletonCard(),
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: SizedBox(
+                  height: 195,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    itemCount: 6,
+                    itemBuilder: (_, _) => const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 4),
+                      child: _SkeletonCard(),
+                    ),
                   ),
                 ),
               ),
@@ -87,7 +95,7 @@ class HomeSkeleton extends StatelessWidget {
           ],
           SliverToBoxAdapter(
             child: SizedBox(
-              height: MediaQuery.paddingOf(context).bottom + 16,
+              height: MediaQuery.paddingOf(context).bottom + 88,
             ),
           ),
         ],
@@ -101,6 +109,8 @@ class _SkeletonCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Two caption lines, matching _MovieCard — a third line here made the
+    // skeleton poster ~13px shorter than the real one.
     return const SizedBox(
       width: 118,
       child: Padding(
@@ -116,11 +126,16 @@ class _SkeletonCard extends StatelessWidget {
               ),
             ),
             SizedBox(height: 6),
-            HomeSkeletonBox(width: 90, height: 11, radius: 3),
-            SizedBox(height: 4),
-            HomeSkeletonBox(width: 60, height: 11, radius: 3),
-            SizedBox(height: 5),
-            HomeSkeletonBox(width: 32, height: 10, radius: 3),
+            FixedTextLines(
+              fontSize: 11.5,
+              lineHeight: 1.25,
+              child: HomeSkeletonBox(width: 90, height: 11, radius: 3),
+            ),
+            FixedTextLines(
+              fontSize: 10,
+              lineHeight: 1.3,
+              child: HomeSkeletonBox(width: 40, height: 10, radius: 3),
+            ),
           ],
         ),
       ),
@@ -143,9 +158,11 @@ class HomeErrorView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final showCloudflare = isCloudflareError(message);
+    // Scrollable: with a long diagnostic and the extra Cloudflare button this
+    // column is taller than a short phone in landscape.
     return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 28),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -231,6 +248,73 @@ class HomeErrorView extends StatelessWidget {
                 ),
               ),
             ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shown when the feed loaded successfully but carries nothing at all — no
+/// hero, no history, no genres, no sections. That state used to render a bare
+/// black screen under the top bar, which is indistinguishable from a hang.
+class HomeEmptyView extends StatelessWidget {
+  const HomeEmptyView({super.key, required this.onRefresh});
+
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.06)),
+              ),
+              child: const Icon(
+                Icons.movie_filter_outlined,
+                color: AppColors.textSecondary,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: 18),
+            Text(
+              'home.empty_title'.tr(),
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                height: 1.25,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'home.empty_subtitle'.tr(),
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 13,
+                height: 1.35,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: 156,
+              height: 44,
+              child: ElevatedButton(
+                onPressed: onRefresh,
+                child: Text('general.retry'.tr()),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/features/home/presentation/widgets/home_top_bar.dart
+++ b/lib/features/home/presentation/widgets/home_top_bar.dart
@@ -1,3 +1,4 @@
+import 'package:soplay/features/anilist/presentation/widgets/anilist_logo.dart';
 import 'dart:async';
 import 'dart:ui';
 
@@ -70,6 +71,13 @@ class HomeTopBar extends StatelessWidget {
           _TopBarIcon(
             icon: Icons.search_rounded,
             onTap: () => getIt<NavController>().goToId(TabId.search),
+          ),
+          // AniList lived four taps deep behind the profile. Discovery and the
+          // airing calendar are things people open daily, and a tracker nobody
+          // can find is a tracker nobody connects.
+          _TopBarIcon.custom(
+            child: const AnilistLogo(size: 19, radius: 5),
+            onTap: () => context.push('/anilist'),
           ),
           _DownloadIndicator(),
           const _NotificationsIndicator(),
@@ -387,6 +395,8 @@ class _ProviderLogo extends StatelessWidget {
               height: size,
               fit: BoxFit.cover,
               errorBuilder: (_, _, _) => fallback,
+              loadingBuilder: (_, child, chunk) =>
+                  chunk == null ? child : fallback,
             ),
     );
   }
@@ -495,7 +505,7 @@ class _NotificationsIndicatorState extends State<_NotificationsIndicator>
           _refresh(force: true);
         },
         child: Padding(
-          padding: const EdgeInsets.all(8),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: SizedBox(
             width: 24,
             height: 24,
@@ -548,9 +558,15 @@ class _NotificationsIndicatorState extends State<_NotificationsIndicator>
 }
 
 class _TopBarIcon extends StatelessWidget {
-  const _TopBarIcon({required this.icon, required this.onTap});
+  const _TopBarIcon({required IconData this.icon, required this.onTap})
+    : child = null;
 
-  final IconData icon;
+  /// For a brand mark, which is an image rather than an icon font glyph.
+  const _TopBarIcon.custom({required Widget this.child, required this.onTap})
+    : icon = null;
+
+  final IconData? icon;
+  final Widget? child;
   final VoidCallback onTap;
 
   @override
@@ -561,8 +577,15 @@ class _TopBarIcon extends StatelessWidget {
         borderRadius: BorderRadius.circular(24),
         onTap: onTap,
         child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Icon(icon, color: Colors.white, size: 24),
+          // Vertical 10 (not 8): a 40dp target was under the minimum, and
+          // widening it instead would overflow the row on a small phone.
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+          // Sized to match the icons beside it, so the row stays even.
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: child ?? Icon(icon, color: Colors.white, size: 24),
+          ),
         ),
       ),
     );
@@ -627,7 +650,7 @@ class _DownloadIndicatorState extends State<_DownloadIndicator>
         borderRadius: BorderRadius.circular(24),
         onTap: () => context.push('/downloads'),
         child: Padding(
-          padding: const EdgeInsets.all(8),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
           child: SizedBox(
             width: 24,
             height: 24,
@@ -649,19 +672,23 @@ class _DownloadIndicatorState extends State<_DownloadIndicator>
                   right: 0,
                   top: 0,
                   child: Container(
-                    width: 12,
-                    height: 12,
-                    decoration: const BoxDecoration(
+                    padding: const EdgeInsets.symmetric(horizontal: 3),
+                    constraints: const BoxConstraints(
+                      minWidth: 12,
+                      minHeight: 12,
+                    ),
+                    decoration: BoxDecoration(
                       color: AppColors.primary,
-                      shape: BoxShape.circle,
+                      borderRadius: BorderRadius.circular(6),
                     ),
                     child: Center(
                       child: Text(
-                        '$_activeCount',
+                        _activeCount > 9 ? '9+' : '$_activeCount',
                         style: const TextStyle(
                           color: Colors.white,
                           fontSize: 7,
                           fontWeight: FontWeight.w900,
+                          height: 1,
                         ),
                       ),
                     ),

--- a/lib/features/home/presentation/widgets/view_all_widgets.dart
+++ b/lib/features/home/presentation/widgets/view_all_widgets.dart
@@ -95,6 +95,12 @@ class ViewAllGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     final bottomPad = MediaQuery.paddingOf(context).bottom;
 
+    // A loaded-but-empty list used to render a bare page with only a title on
+    // it, which reads as a screen that failed to finish loading.
+    if (state.items.isEmpty) {
+      return ViewAllEmptyView(topPadding: appBarH);
+    }
+
     return CustomScrollView(
       controller: scroll,
       slivers: [
@@ -211,26 +217,36 @@ class ViewAllMovieCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 5),
-          Text(
-            movieTitle(movie),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              height: 1.25,
-            ),
-          ),
-          if (movie.year != null)
-            Text(
-              movie.year.toString(),
+          FixedTextLines(
+            fontSize: 11,
+            lineHeight: 1.25,
+            lines: 2,
+            child: Text(
+              movieTitle(movie),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
               style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 10,
-                height: 1.3,
+                color: AppColors.textPrimary,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                height: 1.25,
               ),
             ),
+          ),
+          FixedTextLines(
+            fontSize: 10,
+            lineHeight: 1.3,
+            child: movie.year == null
+                ? null
+                : Text(
+                    movie.year.toString(),
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 10,
+                      height: 1.3,
+                    ),
+                  ),
+          ),
         ],
       ),
     );
@@ -275,6 +291,8 @@ class _SkeletonGridCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Caption block reserves exactly what ViewAllMovieCard reserves, so the
+    // poster does not resize when the real cards replace these.
     return const Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -286,9 +304,17 @@ class _SkeletonGridCard extends StatelessWidget {
           ),
         ),
         SizedBox(height: 5),
-        HomeSkeletonBox(width: double.infinity, height: 10, radius: 3),
-        SizedBox(height: 3),
-        HomeSkeletonBox(width: 50, height: 10, radius: 3),
+        FixedTextLines(
+          fontSize: 11,
+          lineHeight: 1.25,
+          lines: 2,
+          child: HomeSkeletonBox(width: double.infinity, height: 10, radius: 3),
+        ),
+        FixedTextLines(
+          fontSize: 10,
+          lineHeight: 1.3,
+          child: HomeSkeletonBox(width: 50, height: 10, radius: 3),
+        ),
       ],
     );
   }
@@ -303,9 +329,10 @@ class ViewAllErrorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final reason = message.trim();
     return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 28),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -346,6 +373,21 @@ class ViewAllErrorView extends StatelessWidget {
               ),
               textAlign: TextAlign.center,
             ),
+            // The reason was passed in and then dropped on the floor, so every
+            // failure looked like "you are offline". Matches HomeErrorView.
+            if (reason.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              SelectableText(
+                reason,
+                maxLines: 4,
+                style: const TextStyle(
+                  color: AppColors.textHint,
+                  fontSize: 11,
+                  height: 1.35,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
             const SizedBox(height: 24),
             SizedBox(
               width: 156,
@@ -356,6 +398,67 @@ class ViewAllErrorView extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Loaded, but the list came back with nothing in it.
+class ViewAllEmptyView extends StatelessWidget {
+  const ViewAllEmptyView({super.key, required this.topPadding});
+
+  final double topPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(top: topPadding),
+      child: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 72,
+                height: 72,
+                decoration: BoxDecoration(
+                  color: AppColors.surfaceVariant,
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.06),
+                  ),
+                ),
+                child: const Icon(
+                  Icons.movie_filter_outlined,
+                  color: AppColors.textSecondary,
+                  size: 32,
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                'home.list_empty_title'.tr(),
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  height: 1.25,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'home.list_empty_subtitle'.tr(),
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 13,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/live_tv/presentation/pages/live_tv_page.dart
+++ b/lib/features/live_tv/presentation/pages/live_tv_page.dart
@@ -66,6 +66,16 @@ class _LiveTvPageState extends State<LiveTvPage> {
         _loading = false;
         _error = 'live_tv.load_failed'.tr();
       });
+      // A failed pull-to-refresh keeps the line-up on screen, so the failure
+      // has to be said somewhere other than the error state.
+      if (_all.isNotEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_error!),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
     }
   }
 
@@ -125,10 +135,12 @@ class _LiveTvPageState extends State<LiveTvPage> {
   }
 
   Widget _body() {
-    if (_loading) {
+    // Gated on there being nothing to show: a refresh over a loaded line-up
+    // used to swap the whole screen for a spinner and back again.
+    if (_loading && _all.isEmpty) {
       return const Center(child: CircularProgressIndicator(strokeWidth: 2.5));
     }
-    if (_error != null) {
+    if (_error != null && _all.isEmpty) {
       return _Empty(
         icon: Icons.cloud_off_rounded,
         text: _error!,
@@ -271,27 +283,31 @@ class _CategoryBar extends StatelessWidget {
           final value = i == 0 ? '' : categories[i - 1];
           final label = i == 0 ? 'live_tv.all'.tr() : value;
           final active = value == selected;
-          return GestureDetector(
-            onTap: () => onSelect(value),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: active
-                    ? AppColors.primary.withValues(alpha: 0.16)
-                    : AppColors.surface,
-                borderRadius: BorderRadius.circular(18),
-                border: Border.all(
-                  color: active ? AppColors.primary : Colors.transparent,
-                  width: 1.2,
+          return Material(
+            color: active
+                ? AppColors.primary.withValues(alpha: 0.16)
+                : AppColors.surface,
+            borderRadius: BorderRadius.circular(18),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: () => onSelect(value),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 14),
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: active ? AppColors.primary : Colors.transparent,
+                    width: 1.2,
+                  ),
                 ),
-              ),
-              child: Text(
-                label,
-                style: TextStyle(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w600,
-                  color: active ? AppColors.primary : AppColors.textSecondary,
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w600,
+                    color: active ? AppColors.primary : AppColors.textSecondary,
+                  ),
                 ),
               ),
             ),
@@ -319,22 +335,30 @@ class _Grid extends StatelessWidget {
   Widget build(BuildContext context) {
     // Channel logos are wide, not poster-shaped, so the cell is landscape and
     // the count follows the width rather than a fixed number.
+    const gutter = 14.0;
+    const spacing = 10.0;
     final width = MediaQuery.sizeOf(context).width;
     final columns = width >= 900 ? 5 : (width >= 620 ? 4 : 3);
+    final cell = (width - gutter * 2 - spacing * (columns - 1)) / columns;
+    final caption = _ChannelCard.reserveCaption(context);
 
     return SliverPadding(
-      padding: const EdgeInsets.symmetric(horizontal: 14),
+      padding: const EdgeInsets.symmetric(horizontal: gutter),
       sliver: SliverGrid(
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: columns,
-          mainAxisSpacing: 10,
-          crossAxisSpacing: 10,
-          childAspectRatio: 0.92,
+          mainAxisSpacing: spacing,
+          crossAxisSpacing: spacing,
+          // The logo box is what the cell is for, so the caption's two lines
+          // are added to it rather than taken out of it — a fixed ratio let a
+          // long name eat the logo, and a one-line name grow it.
+          childAspectRatio: cell / (cell * 0.73 + caption + 9),
         ),
         delegate: SliverChildBuilderDelegate(
           (context, i) => _ChannelCard(
             channel: channels[i],
             favourite: favourites.contains(channels[i].id),
+            captionHeight: caption,
             onPlay: () => onPlay(channels[i]),
             onFavourite: () => onFavourite(channels[i]),
           ),
@@ -349,82 +373,102 @@ class _ChannelCard extends StatelessWidget {
   const _ChannelCard({
     required this.channel,
     required this.favourite,
+    required this.captionHeight,
     required this.onPlay,
     required this.onFavourite,
   });
 
+  static const double _fontSize = 11.5;
+  static const double _lineHeight = 1.2;
+
+  /// Two lines, always. Channel names run from "TV1" to "Discovery Science HD",
+  /// and letting the caption size itself left every logo in a row at a
+  /// different scale.
+  static double reserveCaption(BuildContext context) =>
+      MediaQuery.textScalerOf(context).scale(_fontSize) * _lineHeight * 2;
+
   final LiveChannel channel;
   final bool favourite;
+  final double captionHeight;
   final VoidCallback onPlay;
   final VoidCallback onFavourite;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onPlay,
-      onLongPress: onFavourite,
-      child: Container(
-        decoration: BoxDecoration(
-          color: AppColors.card,
-          borderRadius: BorderRadius.circular(14),
-          border: Border.all(
-            color: favourite
-                ? AppColors.primary.withValues(alpha: 0.45)
-                : Colors.white.withValues(alpha: 0.06),
+    return Material(
+      color: AppColors.card,
+      borderRadius: BorderRadius.circular(14),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onPlay,
+        onLongPress: onFavourite,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: favourite
+                  ? AppColors.primary.withValues(alpha: 0.45)
+                  : Colors.white.withValues(alpha: 0.06),
+            ),
           ),
-        ),
-        child: Column(
-          children: [
-            Expanded(
-              child: Stack(
-                children: [
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: channel.logoUrl == null
-                          ? _Fallback(name: channel.name)
-                          : CachedNetworkImage(
-                              imageUrl: channel.logoUrl!,
-                              fit: BoxFit.contain,
-                              // Logos come from wherever the playlist points,
-                              // and a dead one is common — the initial reads
-                              // better than a broken-image glyph.
-                              errorWidget: (_, _, _) =>
-                                  _Fallback(name: channel.name),
-                              placeholder: (_, _) =>
-                                  _Fallback(name: channel.name),
-                            ),
-                    ),
-                  ),
-                  if (favourite)
-                    const Positioned(
-                      top: 6,
-                      right: 6,
-                      child: Icon(
-                        Icons.star_rounded,
-                        size: 15,
-                        color: AppColors.primary,
+          child: Column(
+            children: [
+              Expanded(
+                child: Stack(
+                  children: [
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: channel.logoUrl == null
+                            ? _Fallback(name: channel.name)
+                            : CachedNetworkImage(
+                                imageUrl: channel.logoUrl!,
+                                fit: BoxFit.contain,
+                                // Logos come from wherever the playlist points,
+                                // and a dead one is common — the initial reads
+                                // better than a broken-image glyph.
+                                errorWidget: (_, _, _) =>
+                                    _Fallback(name: channel.name),
+                                placeholder: (_, _) =>
+                                    _Fallback(name: channel.name),
+                              ),
                       ),
                     ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(8, 0, 8, 9),
-              child: Text(
-                channel.name,
-                maxLines: 2,
-                textAlign: TextAlign.center,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 11.5,
-                  height: 1.2,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textPrimary,
+                    if (favourite)
+                      const Positioned(
+                        top: 6,
+                        right: 6,
+                        child: Icon(
+                          Icons.star_rounded,
+                          size: 15,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                  ],
                 ),
               ),
-            ),
-          ],
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 0, 8, 9),
+                child: SizedBox(
+                  height: captionHeight,
+                  child: Center(
+                    child: Text(
+                      channel.name,
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: _fontSize,
+                        height: _lineHeight,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/my_list/presentation/widgets/favorite_card.dart
+++ b/lib/features/my_list/presentation/widgets/favorite_card.dart
@@ -18,6 +18,12 @@ class FavoriteCard extends StatelessWidget {
 
   final bool synced;
 
+  static const double titleFontSize = 12;
+  static const double titleLineHeight = 1.18;
+  static const double metaFontSize = 10.5;
+  static const double metaLineHeight = 1.2;
+  static const double metaGap = 3;
+
   @override
   Widget build(BuildContext context) {
     final title =
@@ -107,31 +113,40 @@ class FavoriteCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 7),
-          Text(
-            title,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-              height: 1.18,
-            ),
-          ),
-          if (meta.isNotEmpty) ...[
-            const SizedBox(height: 3),
-            Text(
-              meta,
-              maxLines: 1,
+          FixedTextLines(
+            fontSize: titleFontSize,
+            lineHeight: titleLineHeight,
+            lines: 2,
+            child: Text(
+              title,
+              maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 10.5,
-                fontWeight: FontWeight.w500,
-                height: 1.2,
+                color: AppColors.textPrimary,
+                fontSize: titleFontSize,
+                fontWeight: FontWeight.w700,
+                height: titleLineHeight,
               ),
             ),
-          ],
+          ),
+          const SizedBox(height: metaGap),
+          FixedTextLines(
+            fontSize: metaFontSize,
+            lineHeight: metaLineHeight,
+            child: meta.isEmpty
+                ? null
+                : Text(
+                    meta,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: metaFontSize,
+                      fontWeight: FontWeight.w500,
+                      height: metaLineHeight,
+                    ),
+                  ),
+          ),
         ],
       ),
     );

--- a/lib/features/my_list/presentation/widgets/my_list_header.dart
+++ b/lib/features/my_list/presentation/widgets/my_list_header.dart
@@ -56,7 +56,7 @@ class MyListHeader extends StatelessWidget {
           // on their own page rather than as modes of this one — see
           // UserListsPage — so this is the only way in.
           IconButton(
-            tooltip: 'My Lists',
+            tooltip: 'user_lists.title'.tr(),
             icon: const Icon(
               Icons.playlist_add_check_rounded,
               color: AppColors.textSecondary,

--- a/lib/features/my_list/presentation/widgets/my_list_skeleton.dart
+++ b/lib/features/my_list/presentation/widgets/my_list_skeleton.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:soplay/features/home/presentation/widgets/home_shared_widgets.dart';
+import 'package:soplay/features/my_list/presentation/widgets/favorite_card.dart';
 
 class MyListSkeleton extends StatelessWidget {
   const MyListSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {
+    // Same insets as the loaded grid, so the last row clears the floating nav
+    // bar and nothing shifts sideways when the real cards replace these.
     return SliverPadding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
+      padding: EdgeInsets.fromLTRB(
+        16,
+        0,
+        16,
+        MediaQuery.paddingOf(context).bottom + 96,
+      ),
       sliver: SliverGrid(
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: 142,
@@ -41,9 +49,30 @@ class _SkeletonCard extends StatelessWidget {
             ),
           ),
           SizedBox(height: 7),
-          HomeSkeletonBox(width: double.infinity, height: 12, radius: 4),
-          SizedBox(height: 5),
-          HomeSkeletonBox(width: 72, height: 10, radius: 4),
+          // Caption boxes reserve the same space FavoriteCard does, so the
+          // poster does not resize when the real cards replace these.
+          FixedTextLines(
+            fontSize: FavoriteCard.titleFontSize,
+            lineHeight: FavoriteCard.titleLineHeight,
+            lines: 2,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: HomeSkeletonBox(
+                width: double.infinity,
+                height: 12,
+                radius: 4,
+              ),
+            ),
+          ),
+          SizedBox(height: FavoriteCard.metaGap),
+          FixedTextLines(
+            fontSize: FavoriteCard.metaFontSize,
+            lineHeight: FavoriteCard.metaLineHeight,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: HomeSkeletonBox(width: 72, height: 10, radius: 4),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -50,6 +50,18 @@ class _NotificationsViewState extends State<_NotificationsView> {
     }
   }
 
+  /// Held open until the fetch settles: returning straight away snapped the
+  /// pull-to-refresh spinner shut while the request was still running.
+  Future<void> _refresh() async {
+    final bloc = context.read<NotificationsBloc>();
+    final done = bloc.stream.firstWhere((s) => !s.loading);
+    bloc.add(const NotificationsRefresh());
+    await done.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () => bloc.state,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -99,53 +111,74 @@ class _NotificationsViewState extends State<_NotificationsView> {
               child: CircularProgressIndicator(color: AppColors.primary),
             );
           }
-          if (state.error != null && state.items.isEmpty) {
-            return _ErrorView(
-              message: state.error!,
-              onRetry: () => context
-                  .read<NotificationsBloc>()
-                  .add(const NotificationsRefresh()),
-            );
-          }
-          if (state.isEmpty) {
-            return const _EmptyView();
-          }
+          // The empty and error states are scrollable too: off desktop the
+          // refresh button is hidden, so a pull is the only way back.
           return RefreshIndicator(
             color: AppColors.primary,
             backgroundColor: AppColors.surface,
-            onRefresh: () async {
-              context.read<NotificationsBloc>().add(const NotificationsRefresh());
-            },
-            child: MaxWidthBox(
-              maxWidth: 560,
-              child: ListView.separated(
-              controller: _scroll,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              itemCount: state.items.length + (state.hasMore ? 1 : 0),
-              separatorBuilder: (_, _) => const SizedBox(height: 8),
-              itemBuilder: (context, index) {
-                if (index >= state.items.length) {
-                  return const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16),
-                    child: Center(
-                      child: CircularProgressIndicator(color: AppColors.primary),
-                    ),
-                  );
-                }
-                final item = state.items[index];
-                return _NotificationTile(
-                  item: item,
-                  onTap: () => context
-                      .read<NotificationsBloc>()
-                      .add(NotificationsMarkRead(item.id)),
-                  onDelete: () => context
-                      .read<NotificationsBloc>()
-                      .add(NotificationsDelete(item.id)),
-                );
-              },
-            )),
+            onRefresh: _refresh,
+            child: _body(context, state),
           );
         },
+      ),
+    );
+  }
+
+  Widget _body(BuildContext context, NotificationsState state) {
+    if (state.error != null && state.items.isEmpty) {
+      return _ScrollableFill(
+        child: _ErrorView(message: state.error!, onRetry: _refresh),
+      );
+    }
+    if (state.isEmpty) return const _ScrollableFill(child: _EmptyView());
+
+    return MaxWidthBox(
+      maxWidth: 560,
+      child: ListView.separated(
+        controller: _scroll,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: state.items.length + (state.hasMore ? 1 : 0),
+        separatorBuilder: (_, _) => const SizedBox(height: 8),
+        itemBuilder: (context, index) {
+          if (index >= state.items.length) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(
+                child: CircularProgressIndicator(color: AppColors.primary),
+              ),
+            );
+          }
+          final item = state.items[index];
+          return _NotificationTile(
+            item: item,
+            onTap: () => context
+                .read<NotificationsBloc>()
+                .add(NotificationsMarkRead(item.id)),
+            onDelete: () => context
+                .read<NotificationsBloc>()
+                .add(NotificationsDelete(item.id)),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ScrollableFill extends StatelessWidget {
+  const _ScrollableFill({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: child,
+        ),
       ),
     );
   }
@@ -169,9 +202,10 @@ class _NotificationTile extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
+        onLongPress: isDesktopPlatform ? null : () => _showActions(context),
         child: item.imageUrl != null && item.imageUrl!.isNotEmpty
-            ? _buildImageCard()
-            : _buildTextRow(),
+            ? _buildImageCard(context)
+            : _buildTextRow(context),
       ),
     );
 
@@ -204,19 +238,97 @@ class _NotificationTile extends StatelessWidget {
       direction: DismissDirection.endToStart,
       background: Container(
         alignment: Alignment.centerRight,
-        padding: const EdgeInsets.symmetric(horizontal: 24),
+        padding: const EdgeInsets.symmetric(horizontal: 20),
         decoration: BoxDecoration(
           color: AppColors.error,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: const Icon(Icons.delete_outline, color: Colors.white),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.delete_outline_rounded,
+              color: Colors.white,
+              size: 22,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              'general.delete'.tr(),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
       ),
       onDismissed: (_) => onDelete(),
       child: tile,
     );
   }
 
-  Widget _buildImageCard() {
+  /// The swipe is invisible until it is already under way; long-press exposes
+  /// the same delete for anyone who never discovers it.
+  Future<void> _showActions(BuildContext context) async {
+    final remove = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+      ),
+      builder: (sheetCtx) => SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 8),
+            Container(
+              width: 38,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.textSecondary.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                item.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(
+                Icons.delete_outline_rounded,
+                color: AppColors.error,
+              ),
+              title: Text(
+                'general.delete'.tr(),
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              onTap: () => Navigator.of(sheetCtx).pop(true),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+    if (remove ?? false) onDelete();
+  }
+
+  Widget _buildImageCard(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -228,6 +340,9 @@ class _NotificationTile extends StatelessWidget {
               CachedNetworkImage(
                 imageUrl: item.imageUrl!,
                 fit: BoxFit.cover,
+                placeholder: (_, _) => const ColoredBox(
+                  color: AppColors.surfaceVariant,
+                ),
                 errorWidget: (_, _, _) => const ColoredBox(
                   color: AppColors.surfaceVariant,
                 ),
@@ -274,7 +389,7 @@ class _NotificationTile extends StatelessWidget {
               ],
               const SizedBox(height: 6),
               Text(
-                _formatDate(item.createdAt),
+                _formatDate(context, item.createdAt),
                 style: const TextStyle(
                   color: AppColors.textHint,
                   fontSize: 11,
@@ -287,7 +402,7 @@ class _NotificationTile extends StatelessWidget {
     );
   }
 
-  Widget _buildTextRow() {
+  Widget _buildTextRow(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(14),
       child: Row(
@@ -328,7 +443,7 @@ class _NotificationTile extends StatelessWidget {
                 ],
                 const SizedBox(height: 6),
                 Text(
-                  _formatDate(item.createdAt),
+                  _formatDate(context, item.createdAt),
                   style: const TextStyle(
                     color: AppColors.textHint,
                     fontSize: 11,
@@ -342,20 +457,16 @@ class _NotificationTile extends StatelessWidget {
     );
   }
 
-  String _formatDate(DateTime dt) {
-    final now = DateTime.now();
-    final diff = now.difference(dt);
-    if (diff.inMinutes < 1) return 'notifications.time_now'.tr();
-    if (diff.inHours < 1) {
-      return 'notifications.time_minutes'.tr(args: ['${diff.inMinutes}']);
-    }
-    if (diff.inDays < 1) {
-      return 'notifications.time_hours'.tr(args: ['${diff.inHours}']);
-    }
-    if (diff.inDays < 7) {
-      return 'notifications.time_days'.tr(args: ['${diff.inDays}']);
-    }
-    return '${dt.day}.${dt.month}.${dt.year}';
+  /// Shared wording with the history list, and a locale-aware date past the
+  /// relative window — `3.4.2026` reads as two different days depending on
+  /// where you live.
+  String _formatDate(BuildContext context, DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'time.now'.tr();
+    if (diff.inHours < 1) return 'time.minutes'.tr(args: ['${diff.inMinutes}']);
+    if (diff.inDays < 1) return 'time.hours'.tr(args: ['${diff.inHours}']);
+    if (diff.inDays < 7) return 'time.days'.tr(args: ['${diff.inDays}']);
+    return DateFormat.yMMMd(context.locale.toString()).format(dt);
   }
 }
 

--- a/lib/features/profile/presentation/pages/player_settings_page.dart
+++ b/lib/features/profile/presentation/pages/player_settings_page.dart
@@ -439,7 +439,7 @@ class _SubtitleColorRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
+      padding: const EdgeInsets.fromLTRB(16, 11, 12, 11),
       child: Row(
         children: [
           Container(
@@ -495,7 +495,7 @@ class _SubtitleOpacityRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 10, 16, 6),
+      padding: const EdgeInsets.fromLTRB(16, 4, 12, 4),
       child: Row(
         children: [
           Container(

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,7 +20,6 @@ import 'package:soplay/features/extensions/data/mangayomi_runtime.dart';
 import 'package:soplay/features/extensions/presentation/pages/mangayomi_sources_page.dart';
 import 'package:soplay/features/aniyomi/presentation/pages/aniyomi_sources_page.dart';
 import 'package:soplay/core/manga/manga_channel.dart';
-import 'package:soplay/core/player/player_engine.dart';
 import 'package:soplay/core/storage/hive_service.dart';
 import 'package:soplay/core/system/desktop_window.dart';
 import 'package:soplay/core/system/nav_prefs.dart';
@@ -151,161 +151,9 @@ class _ProfileViewState extends State<_ProfileView> {
                   child: _Reveal(order: 3, child: _ProvidersSection()),
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                if (BridgeControl.canHost && CloudStreamChannel.isSupported) ...[
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Material(
-                        color: AppColors.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        child: ListTile(
-                          leading: ClipRRect(
-                            borderRadius: BorderRadius.circular(6),
-                            child: Image.network(
-                              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTRzeluIShlMnhgHeVHgTSkvsthvQEK2xaS5A&s',
-                              width: 28,
-                              height: 28,
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, _, _) => const Icon(
-                                  Icons.extension_outlined,
-                                  color: AppColors.primary),
-                            ),
-                          ),
-                          title: Text('profile.cloudstream_sources'.tr(),
-                              style: const TextStyle(color: Colors.white)),
-                          trailing: const Icon(Icons.chevron_right,
-                              color: AppColors.textHint),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12)),
-                          onTap: () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const CloudStreamSourcesPage(),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                ],
-                if (BridgeControl.canHost && AniyomiChannel.isSupported) ...[
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Material(
-                        color: AppColors.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        child: ListTile(
-                          leading: ClipRRect(
-                            borderRadius: BorderRadius.circular(6),
-                            child: Image.network(
-                              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcShNP_m0078YcYRUbudCuZhohC2U143Re4MfQ&s',
-                              width: 28,
-                              height: 28,
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, _, _) => const Icon(
-                                  Icons.play_circle_outline,
-                                  color: AppColors.textHint),
-                            ),
-                          ),
-                          title: Text('profile.aniyomi_sources'.tr(),
-                              style: const TextStyle(color: Colors.white)),
-                          trailing: const Icon(Icons.chevron_right,
-                              color: AppColors.textHint),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12)),
-                          onTap: () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const AniyomiSourcesPage(),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                ],
-                if (BridgeControl.canHost && MangaChannel.isSupported) ...[
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Material(
-                        color: AppColors.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        child: ListTile(
-                          leading: ClipRRect(
-                            borderRadius: BorderRadius.circular(6),
-                            child: Image.network(
-                              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcShNP_m0078YcYRUbudCuZhohC2U143Re4MfQ&s',
-                              width: 28,
-                              height: 28,
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, _, _) => const Icon(
-                                  Icons.menu_book_outlined,
-                                  color: AppColors.textHint),
-                            ),
-                          ),
-                          title: Text('manga.sources_title'.tr(),
-                              style: const TextStyle(color: Colors.white)),
-                          trailing: const Icon(Icons.chevron_right,
-                              color: AppColors.textHint),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12)),
-                          onTap: () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const MangaSourcesPage(),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                ],
-                // Not gated on BridgeControl.canHost / a platform channel: these
-                // extensions are JavaScript, so this entry is valid on iOS,
-                // macOS and Windows as well as Android — the only extension
-                // ecosystem that is.
-                if (MangayomiRuntime.isSupported) ...[
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Material(
-                        color: AppColors.surface,
-                        borderRadius: BorderRadius.circular(12),
-                        child: ListTile(
-                          leading: ClipRRect(
-                            borderRadius: BorderRadius.circular(6),
-                            child: Image.network(
-                              'https://raw.githubusercontent.com/kodjodevf/mangayomi/main/assets/app_icons/icon-red.png',
-                              width: 28,
-                              height: 28,
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, _, _) => const Icon(
-                                  Icons.javascript_outlined,
-                                  color: AppColors.textHint),
-                            ),
-                          ),
-                          title: const Text('Mangayomi Sources',
-                              style: TextStyle(color: Colors.white)),
-                          subtitle: const Text('JavaScript · works on iOS too',
-                              style: TextStyle(
-                                  color: AppColors.textHint, fontSize: 11)),
-                          trailing: const Icon(Icons.chevron_right,
-                              color: AppColors.textHint),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12)),
-                          onTap: () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const MangayomiSourcesPage(),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                ],
+                const SliverToBoxAdapter(
+                  child: _Reveal(order: 4, child: _ExtensionSourcesSection()),
+                ),
                 // Signed-in only: approving a TV pairing binds it to an account, so
                 // there is nothing this can do for a guest.
                 SliverToBoxAdapter(
@@ -322,19 +170,15 @@ class _ProfileViewState extends State<_ProfileView> {
                   ),
                 ),
                 const SliverToBoxAdapter(
-                  child: _Reveal(order: 4, child: _WatchHistorySection()),
+                  child: _Reveal(order: 5, child: _WatchHistorySection()),
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: 16)),
                 const SliverToBoxAdapter(
-                  child: _Reveal(order: 5, child: _SecuritySection()),
+                  child: _Reveal(order: 6, child: _SecuritySection()),
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: 16)),
                 const SliverToBoxAdapter(
-                  child: _Reveal(order: 6, child: _AppearanceEntry()),
-                ),
-                const SliverToBoxAdapter(child: SizedBox(height: 16)),
-                const SliverToBoxAdapter(
-                  child: _Reveal(order: 7, child: _PlayerEntry()),
+                  child: _Reveal(order: 7, child: _SettingsEntriesSection()),
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: 16)),
                 const SliverToBoxAdapter(
@@ -852,12 +696,15 @@ class _LogoutButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Tinted, not neutral: signing out is the one destructive control on this
+    // screen and it was indistinguishable from an ordinary icon button.
     return IconButton(
       onPressed: () => _confirmLogout(context),
       icon: const Icon(Icons.logout_rounded, size: 20),
-      color: AppColors.textSecondary,
+      color: AppColors.error,
+      tooltip: 'profile.sign_out'.tr(),
       style: IconButton.styleFrom(
-        backgroundColor: AppColors.surfaceVariant,
+        backgroundColor: AppColors.error.withValues(alpha: 0.12),
         fixedSize: const Size(40, 40),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       ),
@@ -897,7 +744,7 @@ class _LogoutButton extends StatelessWidget {
             child: Text(
               'profile.sign_out'.tr(),
               style: const TextStyle(
-                color: AppColors.primary,
+                color: AppColors.error,
                 fontWeight: FontWeight.w700,
               ),
             ),
@@ -920,7 +767,6 @@ class _ProvidersSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SectionLabel('profile.section_providers'.tr()),
-          const SizedBox(height: 8),
           BlocBuilder<ProviderBloc, ProviderState>(
             builder: (context, state) {
               final loaded = state is ProviderLoaded ? state : null;
@@ -943,12 +789,16 @@ class _ProvidersSection extends StatelessWidget {
                             padding: const EdgeInsets.only(right: 8),
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(6),
-                              child: Image.network(
-                                currentProvider.image,
+                              child: CachedNetworkImage(
+                                imageUrl: currentProvider.image,
                                 width: 22,
                                 height: 22,
                                 fit: BoxFit.cover,
-                                errorBuilder: (_, e, s) =>
+                                // Holds the slot while loading so the name next
+                                // to it does not slide sideways when it lands.
+                                placeholder: (_, _) =>
+                                    const SizedBox(width: 22, height: 22),
+                                errorWidget: (_, _, _) =>
                                     const SizedBox.shrink(),
                               ),
                             ),
@@ -976,11 +826,7 @@ class _ProvidersSection extends StatelessWidget {
                             ),
                           ),
                         const SizedBox(width: 4),
-                        const Icon(
-                          Icons.chevron_right_rounded,
-                          color: AppColors.textHint,
-                          size: 20,
-                        ),
+                        const _TileChevron(),
                       ],
                     ),
                     onTap: () => context.push('/providers'),
@@ -1043,7 +889,6 @@ class _WatchHistorySectionState extends State<_WatchHistorySection> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SectionLabel('profile.section_activity'.tr()),
-          const SizedBox(height: 8),
           _SectionCard(
             children: [
               _Tile(
@@ -1061,16 +906,12 @@ class _WatchHistorySectionState extends State<_WatchHistorySection> {
                         ),
                       ),
                     const SizedBox(width: 4),
-                    const Icon(
-                      Icons.chevron_right_rounded,
-                      color: AppColors.textHint,
-                      size: 20,
-                    ),
+                    const _TileChevron(),
                   ],
                 ),
                 onTap: () => context.push('/history'),
               ),
-              const Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               _Tile(
                 icon: Icons.download_rounded,
                 title: 'profile.downloads'.tr(),
@@ -1086,27 +927,19 @@ class _WatchHistorySectionState extends State<_WatchHistorySection> {
                         ),
                       ),
                     const SizedBox(width: 4),
-                    const Icon(
-                      Icons.chevron_right_rounded,
-                      color: AppColors.textHint,
-                      size: 20,
-                    ),
+                    const _TileChevron(),
                   ],
                 ),
                 onTap: () => context.push('/downloads'),
               ),
-              const Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               _Tile(
                 icon: Icons.notifications_active_outlined,
                 title: 'tracker.title'.tr(),
-                trailing: const Icon(
-                  Icons.chevron_right_rounded,
-                  color: AppColors.textHint,
-                  size: 20,
-                ),
+                trailing: const _TileChevron(),
                 onTap: () => context.push('/following'),
               ),
-              const Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               _Tile(
                 icon: Icons.devices_rounded,
                 title: BridgeControl.canHost
@@ -1114,11 +947,7 @@ class _WatchHistorySectionState extends State<_WatchHistorySection> {
                     : Platform.isIOS
                         ? 'ios.sources_title'.tr()
                         : 'profile.desktop_sources'.tr(),
-                trailing: const Icon(
-                  Icons.chevron_right_rounded,
-                  color: AppColors.textHint,
-                  size: 20,
-                ),
+                trailing: const _TileChevron(),
                 onTap: () => context.push('/desktop-share'),
               ),
             ],
@@ -1138,15 +967,21 @@ class _ConnectionsSection extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: _SectionCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _ConnectionsTile(),
-          _Tile(
-            icon: Icons.live_tv_rounded,
-            title: 'live_tv.title'.tr(),
-            trailing: Icon(Icons.chevron_right_rounded,
-                color: AppColors.textHint, size: 20),
-            onTap: () => context.push('/live-tv'),
+          _SectionLabel('profile.section_connections'.tr()),
+          _SectionCard(
+            children: [
+              const _ConnectionsTile(),
+              const _TileDivider(),
+              _Tile(
+                icon: Icons.live_tv_rounded,
+                title: 'live_tv.title'.tr(),
+                trailing: const _TileChevron(),
+                onTap: () => context.push('/live-tv'),
+              ),
+            ],
           ),
         ],
       ),
@@ -1199,11 +1034,11 @@ class _ConnectionsTileState extends State<_ConnectionsTile> {
       child: InkWell(
         onTap: () => context.push('/connections'),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          padding: const EdgeInsets.fromLTRB(16, 11, 12, 11),
           child: Row(
             children: [
-              const AnilistLogoBadge(size: 38, radius: 10),
-              const SizedBox(width: 13),
+              const AnilistLogoBadge(size: 34, radius: 10),
+              const SizedBox(width: 14),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -1251,8 +1086,7 @@ class _ConnectionsTileState extends State<_ConnectionsTile> {
                   ),
                 )
               else
-                const Icon(Icons.chevron_right_rounded,
-                    color: AppColors.textHint, size: 20),
+                const _TileChevron(),
             ],
           ),
         ),
@@ -1280,7 +1114,6 @@ class _SecuritySectionState extends State<_SecuritySection> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SectionLabel('app_lock.section_label'.tr()),
-          const SizedBox(height: 8),
           _SectionCard(
             children: [
               _Tile(
@@ -1302,11 +1135,7 @@ class _SecuritySectionState extends State<_SecuritySection> {
                       ),
                     ),
                     const SizedBox(width: 6),
-                    const Icon(
-                      Icons.chevron_right_rounded,
-                      color: AppColors.textHint,
-                      size: 20,
-                    ),
+                    const _TileChevron(),
                   ],
                 ),
                 onTap: () async {
@@ -1314,15 +1143,11 @@ class _SecuritySectionState extends State<_SecuritySection> {
                   if (mounted) setState(() {});
                 },
               ),
-              const Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               _Tile(
                 icon: Icons.folder_special_rounded,
                 title: 'app_lock.private_list'.tr(),
-                trailing: const Icon(
-                  Icons.chevron_right_rounded,
-                  color: AppColors.textHint,
-                  size: 20,
-                ),
+                trailing: const _TileChevron(),
                 onTap: () async {
                   final unlocked = await requestPrivateUnlock(context);
                   if (unlocked && context.mounted) {
@@ -1494,7 +1319,6 @@ class _AppearanceSectionState extends State<_AppearanceSection> {
         children: [
           if (widget.showLabel) ...[
             _SectionLabel('profile.section_appearance'.tr()),
-            const SizedBox(height: 8),
           ],
           _SectionCard(
             children: [
@@ -1562,8 +1386,7 @@ class _AppearanceSectionState extends State<_AppearanceSection> {
                       subtitle: Text('nav_customize.entry_subtitle'.tr(),
                           style: const TextStyle(
                               color: AppColors.textHint, fontSize: 12)),
-                      trailing: const Icon(Icons.chevron_right,
-                          color: AppColors.textHint),
+                      trailing: const _TileChevron(),
                       onTap: () => showTabCustomizer(context),
                     ),
                   ),
@@ -1601,51 +1424,43 @@ class NavbarPage extends StatelessWidget {
   }
 }
 
-/// Compact Profile entry (matches the security tiles) → opens [AppearancePage].
-class _AppearanceEntry extends StatelessWidget {
-  const _AppearanceEntry();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: _SectionCard(
-        children: [
-          _Tile(
-            icon: Icons.view_week_rounded,
-            title: 'profile.nav_style'.tr(),
-            trailing: const Icon(Icons.chevron_right_rounded,
-                color: AppColors.textHint, size: 20),
-            onTap: () => context.push('/navbar'),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Compact Profile entry → [PlayerSettingsPage].
+/// The two rows that open a settings sub-page ([NavbarPage],
+/// [PlayerSettingsPage]).
 ///
-/// Unconditional, unlike the engine picker it replaced: that was Android-only
-/// because every other platform is pinned to one backend, but the page now
-/// also owns playback defaults and subtitle appearance, which apply
-/// everywhere. The engine block inside is still gated on
-/// [canChoosePlayerEngine].
-class _PlayerEntry extends StatelessWidget {
-  const _PlayerEntry();
+/// One labelled card rather than two unlabelled single-row cards: floating
+/// alone between the labelled Security and About sections, they read as
+/// leftovers rather than as a group.
+///
+/// The Player row is unconditional — the page behind it owns playback defaults
+/// and subtitle appearance, which apply everywhere; only its engine block is
+/// platform-gated.
+class _SettingsEntriesSection extends StatelessWidget {
+  const _SettingsEntriesSection();
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: _SectionCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _Tile(
-            icon: Icons.play_circle_outline_rounded,
-            title: 'profile.section_player'.tr(),
-            trailing: const Icon(Icons.chevron_right_rounded,
-                color: AppColors.textHint, size: 20),
-            onTap: () => context.push('/player-settings'),
+          _SectionLabel('profile.section_settings'.tr()),
+          _SectionCard(
+            children: [
+              _Tile(
+                icon: Icons.view_week_rounded,
+                title: 'profile.nav_style'.tr(),
+                trailing: const _TileChevron(),
+                onTap: () => context.push('/navbar'),
+              ),
+              const _TileDivider(),
+              _Tile(
+                icon: Icons.play_circle_outline_rounded,
+                title: 'profile.section_player'.tr(),
+                trailing: const _TileChevron(),
+                onTap: () => context.push('/player-settings'),
+              ),
+            ],
           ),
         ],
       ),
@@ -1655,6 +1470,10 @@ class _PlayerEntry extends StatelessWidget {
 
 class _AboutSection extends StatelessWidget {
   const _AboutSection();
+
+  /// Resolved once. Rebuilt per build() it dropped the version row back to "…"
+  /// on every rebuild of the list.
+  static final Future<PackageInfo> _packageInfo = PackageInfo.fromPlatform();
 
   Future<void> _open(String url) async {
     final uri = Uri.parse(url);
@@ -1786,14 +1605,13 @@ class _AboutSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SectionLabel('profile.section_about'.tr()),
-          const SizedBox(height: 8),
           _SectionCard(
             children: [
               _Tile(
                 icon: Icons.info_outline_rounded,
                 title: 'Sozo',
                 trailing: FutureBuilder<PackageInfo>(
-                  future: PackageInfo.fromPlatform(),
+                  future: _packageInfo,
                   builder: (_, snap) => Text(
                     snap.hasData
                         ? 'v${snap.data!.version} (${snap.data!.buildNumber})'
@@ -1804,7 +1622,7 @@ class _AboutSection extends StatelessWidget {
                 ),
                 onTap: null,
               ),
-              Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               _Tile(
                 icon: Icons.person_outline_rounded,
                 title: 'profile.developer'.tr(),
@@ -1817,16 +1635,12 @@ class _AboutSection extends StatelessWidget {
                           TextStyle(color: AppColors.textSecondary, fontSize: 13),
                     ),
                     SizedBox(width: 4),
-                    Icon(
-                      Icons.chevron_right_rounded,
-                      color: AppColors.textHint,
-                      size: 20,
-                    ),
+                    _TileChevron(),
                   ],
                 ),
                 onTap: () => _showDeveloper(context),
               ),
-              Divider(color: AppColors.divider, height: 1),
+              const _TileDivider(),
               const _ServerCountdownTile(),
             ],
           ),
@@ -1946,56 +1760,131 @@ class _SectionLabel extends StatelessWidget {
   }
 }
 
+/// A Profile row. Metrics are the ones in `settings_tiles.dart` so a row here
+/// and a row on the page it opens sit on the same grid.
 class _Tile extends StatelessWidget {
   const _Tile({
-    required this.icon,
+    this.icon,
+    this.leading,
     required this.title,
     required this.trailing,
     required this.onTap,
+    this.subtitle,
   });
 
-  final IconData icon;
+  final IconData? icon;
+
+  /// Drawn in place of the icon chip, in the same 34px box so the column of
+  /// leading marks does not shift between rows.
+  final Widget? leading;
   final String title;
+  final String? subtitle;
   final Widget trailing;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
+    final sub = subtitle;
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: onTap,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          child: Row(
-            children: [
-              Container(
-                width: 34,
-                height: 34,
-                decoration: BoxDecoration(
-                  color: AppColors.textSecondary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: Icon(icon, color: AppColors.textSecondary, size: 18),
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Text(
-                  title,
-                  style: const TextStyle(
-                    color: AppColors.textPrimary,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
+          padding: const EdgeInsets.fromLTRB(16, 11, 12, 11),
+          child: LayoutBuilder(
+            builder: (context, constraints) => Row(
+              children: [
+                _TileLeading(icon: icon, child: leading),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      if (sub != null && sub.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          sub,
+                          style: const TextStyle(
+                            color: AppColors.textHint,
+                            fontSize: 11.5,
+                            height: 1.3,
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
-              ),
-              trailing,
-            ],
+                const SizedBox(width: 8),
+                // Half the row at most: past that the value wins the tug of
+                // war with the title and pushes it into a wrapped column.
+                ConstrainedBox(
+                  constraints:
+                      BoxConstraints(maxWidth: constraints.maxWidth * 0.5),
+                  child: trailing,
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
+}
+
+class _TileLeading extends StatelessWidget {
+  const _TileLeading({this.icon, this.child});
+
+  final IconData? icon;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final custom = child;
+    if (custom != null) {
+      return SizedBox(width: 34, height: 34, child: custom);
+    }
+    return Container(
+      width: 34,
+      height: 34,
+      decoration: BoxDecoration(
+        color: AppColors.textSecondary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: icon == null
+          ? null
+          : Icon(icon, color: AppColors.textSecondary, size: 18),
+    );
+  }
+}
+
+/// Inset to the title column, like [SettingsDivider] on the sub-pages.
+class _TileDivider extends StatelessWidget {
+  const _TileDivider();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Divider(color: AppColors.divider, height: 1, indent: 64);
+}
+
+/// Chevron used by every row that opens something.
+class _TileChevron extends StatelessWidget {
+  const _TileChevron();
+
+  @override
+  Widget build(BuildContext context) => const Icon(
+        Icons.chevron_right_rounded,
+        color: AppColors.textHint,
+        size: 20,
+      );
 }
 
 class _Avatar extends StatelessWidget {
@@ -2118,62 +2007,35 @@ class _ServerCountdownTileState extends State<_ServerCountdownTile> {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: () => _showSupportSheet(context),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          child: Row(
-            children: [
-              Container(
-                width: 34,
-                height: 34,
-                decoration: BoxDecoration(
-                  color: AppColors.textSecondary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: const Icon(
-                  Icons.dns_outlined,
-                  color: AppColors.textSecondary,
-                  size: 18,
-                ),
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Text(
-                  'profile.server'.tr(),
-                  style: const TextStyle(
-                    color: AppColors.textPrimary,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
+    return _Tile(
+      icon: Icons.dns_outlined,
+      title: 'profile.server'.tr(),
+      onTap: () => _showSupportSheet(context),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: ValueListenableBuilder<Duration>(
+              valueListenable: _remaining,
+              builder: (_, rem, _) {
+                return Text(
+                  rem == Duration.zero ? 'profile.expired'.tr() : _fmt(rem),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: rem == Duration.zero
+                        ? AppColors.primary
+                        : AppColors.textSecondary,
+                    fontSize: 13,
+                    fontFeatures: const [FontFeature.tabularFigures()],
                   ),
-                ),
-              ),
-              ValueListenableBuilder<Duration>(
-                valueListenable: _remaining,
-                builder: (_, rem, _) {
-                  return Text(
-                    rem == Duration.zero ? 'profile.expired'.tr() : _fmt(rem),
-                    style: TextStyle(
-                      color: rem == Duration.zero
-                          ? AppColors.primary
-                          : AppColors.textSecondary,
-                      fontSize: 13,
-                      fontFeatures: const [FontFeature.tabularFigures()],
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(width: 4),
-              const Icon(
-                Icons.chevron_right_rounded,
-                color: AppColors.textHint,
-                size: 20,
-              ),
-            ],
+                );
+              },
+            ),
           ),
-        ),
+          const SizedBox(width: 4),
+          const _TileChevron(),
+        ],
       ),
     );
   }
@@ -2354,23 +2216,132 @@ class _LinkTvTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Material(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-        child: ListTile(
-          leading: const Icon(Icons.cast_connected, color: AppColors.primary),
-          title: Text('link_tv.title'.tr(),
-              style: const TextStyle(color: Colors.white)),
-          subtitle: Text('link_tv.tile_subtitle'.tr(),
-              style: const TextStyle(color: AppColors.textHint, fontSize: 11)),
-          trailing:
-              const Icon(Icons.chevron_right, color: AppColors.textHint),
-          shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12)),
+      child: _SectionCard(
+        children: [
+          _Tile(
+            icon: Icons.cast_connected,
+            title: 'link_tv.title'.tr(),
+            subtitle: 'link_tv.tile_subtitle'.tr(),
+            trailing: const _TileChevron(),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const LinkTvPage()),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The installable-extension entries, in one card instead of four free-standing
+/// ones. Which of them exist depends on the platform, so the card builds itself
+/// out of whatever is supported and disappears entirely when nothing is.
+class _ExtensionSourcesSection extends StatelessWidget {
+  const _ExtensionSourcesSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <Widget>[
+      if (BridgeControl.canHost && CloudStreamChannel.isSupported)
+        _Tile(
+          leading: const _TileLogo(
+            url:
+                'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTRzeluIShlMnhgHeVHgTSkvsthvQEK2xaS5A&s',
+            fallback: Icons.extension_outlined,
+          ),
+          title: 'profile.cloudstream_sources'.tr(),
+          trailing: const _TileChevron(),
           onTap: () => Navigator.of(context).push(
-            MaterialPageRoute(builder: (_) => const LinkTvPage()),
+            MaterialPageRoute(builder: (_) => const CloudStreamSourcesPage()),
           ),
         ),
+      if (BridgeControl.canHost && AniyomiChannel.isSupported)
+        _Tile(
+          leading: const _TileLogo(
+            url:
+                'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcShNP_m0078YcYRUbudCuZhohC2U143Re4MfQ&s',
+            fallback: Icons.play_circle_outline,
+          ),
+          title: 'profile.aniyomi_sources'.tr(),
+          trailing: const _TileChevron(),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const AniyomiSourcesPage()),
+          ),
+        ),
+      if (BridgeControl.canHost && MangaChannel.isSupported)
+        _Tile(
+          leading: const _TileLogo(
+            url:
+                'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcShNP_m0078YcYRUbudCuZhohC2U143Re4MfQ&s',
+            fallback: Icons.menu_book_outlined,
+          ),
+          title: 'manga.sources_title'.tr(),
+          trailing: const _TileChevron(),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const MangaSourcesPage()),
+          ),
+        ),
+      // Not gated on BridgeControl.canHost / a platform channel: these
+      // extensions are JavaScript, so this entry is valid on iOS, macOS and
+      // Windows as well as Android — the only extension ecosystem that is.
+      if (MangayomiRuntime.isSupported)
+        _Tile(
+          leading: const _TileLogo(
+            url:
+                'https://raw.githubusercontent.com/kodjodevf/mangayomi/main/assets/app_icons/icon-red.png',
+            fallback: Icons.javascript_outlined,
+          ),
+          title: 'Mangayomi Sources',
+          trailing: const _TileChevron(),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const MangayomiSourcesPage()),
+          ),
+        ),
+    ];
+    if (rows.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionLabel('profile.section_extensions'.tr()),
+          _SectionCard(
+            children: [
+              for (var i = 0; i < rows.length; i++) ...[
+                if (i > 0) const _TileDivider(),
+                rows[i],
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Remote logo in the leading slot. Shows the plain icon chip while loading and
+/// if the load fails, so the row never has a hole where its mark should be.
+class _TileLogo extends StatelessWidget {
+  const _TileLogo({required this.url, required this.fallback});
+
+  final String url;
+  final IconData fallback;
+
+  @override
+  Widget build(BuildContext context) {
+    final cache = (34 * MediaQuery.devicePixelRatioOf(context)).round();
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(10),
+      child: CachedNetworkImage(
+        imageUrl: url,
+        width: 34,
+        height: 34,
+        fit: BoxFit.cover,
+        memCacheWidth: cache,
+        memCacheHeight: cache,
+        placeholder: (_, _) => _TileLeading(icon: fallback),
+        errorWidget: (_, _, _) => _TileLeading(icon: fallback),
       ),
     );
   }

--- a/lib/features/profile/presentation/pages/providers_page.dart
+++ b/lib/features/profile/presentation/pages/providers_page.dart
@@ -703,7 +703,9 @@ class _ProviderListTile extends StatelessWidget {
                     minWidth: 34,
                     minHeight: 34,
                   ),
-                  tooltip: 'profile.add_favorite'.tr(),
+                  tooltip: isFavorite
+                      ? 'profile.remove_favorite'.tr()
+                      : 'profile.add_favorite'.tr(),
                 ),
                 const SizedBox(width: 2),
                 if (selected)

--- a/lib/features/profile/presentation/widgets/settings_tiles.dart
+++ b/lib/features/profile/presentation/widgets/settings_tiles.dart
@@ -161,12 +161,16 @@ class SettingsDropdownTile<T> extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              labelOf(value),
-              style: TextStyle(
-                color: enabled ? AppColors.primary : AppColors.textHint,
-                fontSize: 13.5,
-                fontWeight: FontWeight.w600,
+            Flexible(
+              child: Text(
+                labelOf(value),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: enabled ? AppColors.primary : AppColors.textHint,
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
             const SizedBox(width: 2),
@@ -216,6 +220,9 @@ class SettingsSwitchTile extends StatelessWidget {
         onChanged: enabled ? onChanged : null,
         activeThumbColor: Colors.white,
         activeTrackColor: AppColors.primary,
+        // The row is the tap target, so the switch's own 48px material one only
+        // ever made switch rows taller than the dropdown rows beside them.
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       ),
     );
   }
@@ -250,49 +257,57 @@ class _SettingsRow extends StatelessWidget {
           opacity: enabled ? 1 : 0.45,
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 11, 12, 11),
-            child: Row(
-              children: [
-                Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: AppColors.textSecondary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(10),
+            child: LayoutBuilder(
+              builder: (context, constraints) => Row(
+                children: [
+                  Container(
+                    width: 34,
+                    height: 34,
+                    decoration: BoxDecoration(
+                      color: AppColors.textSecondary.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child:
+                        Icon(icon, color: AppColors.textSecondary, size: 18),
                   ),
-                  child:
-                      Icon(icon, color: AppColors.textSecondary, size: 18),
-                ),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        title,
-                        style: const TextStyle(
-                          color: AppColors.textPrimary,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      if (sub != null && sub.isNotEmpty) ...[
-                        const SizedBox(height: 2),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
                         Text(
-                          sub,
+                          title,
                           style: const TextStyle(
-                            color: AppColors.textHint,
-                            fontSize: 11.5,
-                            height: 1.3,
+                            color: AppColors.textPrimary,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w500,
                           ),
                         ),
+                        if (sub != null && sub.isNotEmpty) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            sub,
+                            style: const TextStyle(
+                              color: AppColors.textHint,
+                              fontSize: 11.5,
+                              height: 1.3,
+                            ),
+                          ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                trailing,
-              ],
+                  const SizedBox(width: 8),
+                  // Half the row at most: past that the value wins the tug of
+                  // war with the title and pushes it into a wrapped column.
+                  ConstrainedBox(
+                    constraints:
+                        BoxConstraints(maxWidth: constraints.maxWidth * 0.5),
+                    child: trailing,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/profile/presentation/widgets/tab_customizer_sheet.dart
+++ b/lib/features/profile/presentation/widgets/tab_customizer_sheet.dart
@@ -64,10 +64,8 @@ class _TabCustomizerSheetState extends State<_TabCustomizerSheet> {
     setState(() => _draft.remove(id));
   }
 
-  void _reorder(int oldI, int newI) => setState(() {
-        if (newI > oldI) newI -= 1;
-        _draft.insert(newI, _draft.removeAt(oldI));
-      });
+  void _reorder(int oldI, int newI) =>
+      setState(() => _draft.insert(newI, _draft.removeAt(oldI)));
 
   Future<void> _save() async {
     if (!_valid) {
@@ -114,7 +112,7 @@ class _TabCustomizerSheetState extends State<_TabCustomizerSheet> {
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             buildDefaultDragHandles: false,
-            onReorder: _reorder,
+            onReorderItem: _reorder,
             proxyDecorator: (child, i, anim) =>
                 Material(color: Colors.transparent, child: child),
             children: [
@@ -191,16 +189,19 @@ class _PinnedTile extends StatelessWidget {
                   fontSize: 15,
                   fontWeight: FontWeight.w600)),
         ),
+        // Same 40px box the remove button occupies, so the drag handles stay in
+        // one column whether or not a tab is locked.
         if (def.mandatory)
-          const Padding(
-            padding: EdgeInsets.only(right: 6),
+          const SizedBox(
+            width: 40,
+            height: 40,
             child: Icon(Icons.lock_rounded, color: AppColors.textHint, size: 18),
           )
         else
           IconButton(
             visualDensity: VisualDensity.compact,
             icon: const Icon(Icons.remove_circle_rounded,
-                color: Color(0xFFE53935), size: 22),
+                color: AppColors.error, size: 22),
             onPressed: onRemove,
           ),
         ReorderableDragStartListener(

--- a/lib/features/search/domain/entities/cross_search_scope.dart
+++ b/lib/features/search/domain/entities/cross_search_scope.dart
@@ -1,0 +1,76 @@
+import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
+
+/// Which sources an all-source search covers.
+///
+/// Deliberately *not* a plain `Set<String>`: "every source" and "these twelve
+/// sources, which happen to be all of them today" behave differently the moment
+/// the installed list changes. A frozen id set silently stops covering a source
+/// the user installs later, and an empty set is indistinguishable from "the user
+/// has not chosen yet" — which is how the page ended up searching one provider
+/// and reporting "0 of 1".
+class CrossSearchScope {
+  const CrossSearchScope.all() : ids = null;
+
+  const CrossSearchScope._only(this.ids);
+
+  /// Narrows to [ids]; an empty selection is not a scope, it is [all].
+  factory CrossSearchScope.only(Iterable<String> ids) {
+    final set = ids.toSet();
+    return set.isEmpty ? const CrossSearchScope.all() : CrossSearchScope._only(set);
+  }
+
+  /// Null means "everything usable", which is the default.
+  final Set<String>? ids;
+
+  bool get isAll => ids == null;
+
+  /// The stored form: an empty list means [all], so a user who never opened the
+  /// picker searches everything rather than inheriting some other screen's
+  /// notion of a "current" provider.
+  factory CrossSearchScope.fromStored(List<String> stored) =>
+      CrossSearchScope.only(stored);
+
+  List<String> toStored() => ids?.toList() ?? const [];
+
+  bool includes(String id) => ids == null || ids!.contains(id);
+
+  List<ProviderEntity> resolve(List<ProviderEntity> providers) =>
+      ids == null ? providers : providers.where((p) => ids!.contains(p.id)).toList();
+
+  int selectedCount(List<ProviderEntity> providers) => resolve(providers).length;
+
+  /// Drops ids that are no longer installed. Narrowing to nothing widens back
+  /// to [all] rather than leaving a search with no legs at all, and a narrowing
+  /// that names every installed source collapses to [all] too — the old picker
+  /// persisted exactly that list when a user ticked everything, and read back
+  /// literally it would pin them to the list as it stood that day.
+  CrossSearchScope pruned(List<ProviderEntity> providers) {
+    if (ids == null) return this;
+    final kept = ids!.where((id) => providers.any((p) => p.id == id)).toSet();
+    if (providers.isNotEmpty && kept.length == providers.length) {
+      return const CrossSearchScope.all();
+    }
+    return CrossSearchScope.only(kept);
+  }
+
+  /// One tap on a source chip.
+  ///
+  /// From [all] a tap means "just this one" — the chips read as unselected
+  /// there, so the alternative ("everything except this one") would be the
+  /// opposite of what the control looks like it does.
+  CrossSearchScope toggle(String id) {
+    if (ids == null) return CrossSearchScope.only({id});
+    final next = {...ids!};
+    if (!next.remove(id)) next.add(id);
+    return CrossSearchScope.only(next);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is CrossSearchScope &&
+      (ids == null) == (other.ids == null) &&
+      (ids == null || (ids!.length == other.ids!.length && ids!.containsAll(other.ids!)));
+
+  @override
+  int get hashCode => ids == null ? 0 : Object.hashAllUnordered(ids!);
+}

--- a/lib/features/search/presentation/blocs/cross_search_controller.dart
+++ b/lib/features/search/presentation/blocs/cross_search_controller.dart
@@ -45,9 +45,33 @@ class CrossSearchController extends ChangeNotifier {
   List<ProviderRef> get providerSet => _set;
 
   int get expectedLegs => _set.length;
-  int get completedLegs => _results.length;
+  int get completedLegs => results.length;
   int get totalItems => _results.values.fold(0, (s, r) => s + r.items.length);
   int get sourcesWithResults => _results.values.where((r) => r.hasItems).length;
+
+  /// The four outcomes kept apart, because "searched and found nothing",
+  /// "blew up", "took too long" and "has not answered yet" are four different
+  /// answers and the summary used to render all of them as a missing source.
+  int get emptySources => _countStatus(ProviderSearchStatus.empty);
+  int get erroredSources => _countStatus(ProviderSearchStatus.error);
+  int get timedOutSources => _countStatus(ProviderSearchStatus.timeout);
+  int get brokenSources => erroredSources + timedOutSources;
+  int get runningSources => expectedLegs - completedLegs;
+
+  int _countStatus(ProviderSearchStatus status) =>
+      results.where((r) => r.status == status).length;
+
+  /// Nothing answered usefully and every leg that did answer broke — the state
+  /// that must never be reported as "no results".
+  bool get everySourceBroken =>
+      _phase == CrossSearchPhase.done &&
+      expectedLegs > 0 &&
+      brokenSources == expectedLegs;
+
+  /// A query the user is still typing that is too short to fan out on. Without
+  /// this the page showed a finished-looking "0 results" for a single letter.
+  bool get awaitingLongerQuery =>
+      _phase == CrossSearchPhase.idle && _query.isNotEmpty;
 
   /// Every leg in the selected order — answered or not.
   List<ProviderSearchResult> get results => [
@@ -115,13 +139,30 @@ class CrossSearchController extends ChangeNotifier {
   }
 
   void setProviderSet(List<ProviderRef> set) {
+    if (_sameSet(set)) return;
     _set = set;
-    _cache.clear();
+    _results.clear();
+    _retrying.clear();
+    _merged = const [];
     if (_query.isEmpty) {
+      _phase = CrossSearchPhase.idle;
       notifyListeners();
       return;
     }
+    _cancel();
+    // The cache is keyed by set + query, so toggling a source off and back on
+    // is instant instead of re-running every other leg from scratch.
+    if (_restoreFromCache(_query)) return;
+    _debouncer.reset();
     _run(_query);
+  }
+
+  bool _sameSet(List<ProviderRef> set) {
+    if (set.length != _set.length) return false;
+    for (var i = 0; i < set.length; i++) {
+      if (set[i].id != _set[i].id) return false;
+    }
+    return true;
   }
 
   /// Re-runs a single source. A first-ever extension search has to download and
@@ -142,6 +183,13 @@ class CrossSearchController extends ChangeNotifier {
     _results[ref.id] = result;
     _remerge();
     notifyListeners();
+  }
+
+  /// Every leg that failed or timed out, at once.
+  Future<void> retryFailed() async {
+    final ids = [for (final leg in failedLegs) leg.provider.id];
+    if (ids.isEmpty) return;
+    await Future.wait(ids.map(retryProvider));
   }
 
   /// Whether a [loadMore] is in flight, so the button can say so and refuse a
@@ -228,6 +276,10 @@ class CrossSearchController extends ChangeNotifier {
   void _remerge() => _merged = mergeSearchResults(results);
 
   void _store(String q) {
+    // Never replay a run that contains a failure: retyping the query is how a
+    // user asks for another attempt, and serving them the cached failure for
+    // the next five minutes is indistinguishable from the app being broken.
+    if (failedLegs.isNotEmpty) return;
     _cache.remove(_cacheKey(q));
     _cache[_cacheKey(q)] = _CachedRun(
       at: DateTime.now(),

--- a/lib/features/search/presentation/pages/cross_search_page.dart
+++ b/lib/features/search/presentation/pages/cross_search_page.dart
@@ -163,11 +163,18 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
       _push(title.hits.first);
       return;
     }
+    // Scrollable and height-capped: the list is as long as the number of sources that
+    // matched, which is exactly what all-source search is for, and a fixed Column ran off
+    // the bottom of the sheet as soon as it found more than a handful.
     showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
       backgroundColor: AppColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.7,
       ),
       builder: (_) => SafeArea(
         child: Column(
@@ -185,23 +192,33 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
                 ),
               ),
             ),
-            for (final hit in title.hits)
-              ListTile(
-                dense: true,
-                leading: const Icon(Icons.play_circle_outline,
-                    color: AppColors.primary, size: 20),
-                title: Text(hit.provider.name,
-                    style: const TextStyle(color: Colors.white, fontSize: 14)),
-                subtitle: Text(hit.item.title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                        color: AppColors.textHint, fontSize: 12)),
-                onTap: () {
-                  Navigator.of(context).pop();
-                  _push(hit);
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                padding: const EdgeInsets.only(bottom: 8),
+                itemCount: title.hits.length,
+                itemBuilder: (_, i) {
+                  final hit = title.hits[i];
+                  return ListTile(
+                    dense: true,
+                    leading: const Icon(Icons.play_circle_outline,
+                        color: AppColors.primary, size: 20),
+                    title: Text(hit.provider.name,
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 14)),
+                    subtitle: Text(hit.item.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                            color: AppColors.textHint, fontSize: 12)),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      _push(hit);
+                    },
+                  );
                 },
               ),
+            ),
           ],
         ),
       ),

--- a/lib/features/search/presentation/pages/cross_search_page.dart
+++ b/lib/features/search/presentation/pages/cross_search_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,13 +13,24 @@ import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
 import 'package:soplay/features/profile/presentation/bloc/provider_bloc.dart';
 import 'package:soplay/features/profile/presentation/bloc/provider_state.dart';
 import 'package:soplay/features/search/domain/entities/cross_search_result.dart';
+import 'package:soplay/features/search/domain/entities/cross_search_scope.dart';
 import 'package:soplay/features/search/domain/services/cross_search_engine.dart';
 import 'package:soplay/features/search/presentation/blocs/cross_search_controller.dart';
+import 'package:soplay/features/search/presentation/blocs/search_query_policy.dart';
 import 'package:soplay/features/search/presentation/widgets/search_result_card.dart';
 import 'package:soplay/features/search/presentation/widgets/search_set_sheet.dart';
+import 'package:soplay/features/search/presentation/widgets/source_scope_bar.dart';
+
 class CrossSearchPage extends StatefulWidget {
-  const CrossSearchPage({super.key, this.initialQuery});
+  const CrossSearchPage({super.key, this.initialQuery, this.initialProviderIds});
+
   final String? initialQuery;
+
+  /// Start narrowed to these sources. Used when the caller already knows which
+  /// one it wants — picking a source on an AniList title, say. It is a starting
+  /// point, not a setting: it is never persisted, and the "All sources" chip
+  /// sits next to it so widening back is one tap.
+  final Set<String>? initialProviderIds;
 
   @override
   State<CrossSearchPage> createState() => _CrossSearchPageState();
@@ -27,19 +40,30 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
   final _textController = TextEditingController();
   late final CrossSearchController _controller;
 
-  Set<String> _selectedIds = {};
+  CrossSearchScope _scope = const CrossSearchScope.all();
   List<ProviderEntity> _providers = const [];
+
+  /// Chip order, recomputed only when the provider list or the picker changes
+  /// it — never on a chip tap, so a chip cannot move out from under the finger.
+  List<String> _railOrder = const [];
   bool _offline = false;
+  bool _loadingProviders = true;
   bool _grouped = false;
+
+  /// Searching every source can mean hundreds of legs, so the per-source list
+  /// is only built while it is open.
+  bool _statusOpen = false;
 
   @override
   void initState() {
     super.initState();
-    _providers = _providersOf(context.read<ProviderBloc>().state);
-    _selectedIds = _initialSelection(_providers);
+    final state = context.read<ProviderBloc>().state;
+    _adoptProviders(state);
+    _scope = _initialScope(_providers);
+    _railOrder = _orderedIds(_providers, _scope);
     _controller = CrossSearchController(
       engine: getIt<CrossSearchEngine>(),
-      set: _buildRefs(_providers, _selectedIds),
+      set: _refs(),
     );
     final q = widget.initialQuery?.trim() ?? '';
     if (q.isNotEmpty) {
@@ -60,62 +84,78 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
   List<ProviderEntity> _providersOf(ProviderState state) =>
       state is ProviderLoaded ? state.usableProviders : const [];
 
+  void _adoptProviders(ProviderState state) {
+    _providers = _providersOf(state);
+    _offline = state is ProviderLoaded && state.offline;
+    _loadingProviders = state is! ProviderLoaded && state is! ProviderError;
+  }
+
   /// The page used to snapshot ProviderBloc once in initState, so opening it
   /// before the providers had loaded left it permanently empty.
   void _syncProviders(ProviderState state) {
-    final providers = _providersOf(state);
+    final next = _providersOf(state);
+    final sameList = next.length == _providers.length &&
+        next.every((p) => _providers.any((e) => e.id == p.id));
     final offline = state is ProviderLoaded && state.offline;
-    if (providers.length == _providers.length &&
-        offline == _offline &&
-        providers.every((p) => _providers.any((e) => e.id == p.id))) {
-      return;
-    }
-    final wasEmpty = _providers.isEmpty;
-    _providers = providers;
-    _offline = offline;
-    if (wasEmpty || _selectedIds.isEmpty) {
-      _selectedIds = _initialSelection(providers);
-    } else {
-      _selectedIds = _selectedIds
-          .where((id) => providers.any((p) => p.id == id))
-          .toSet();
-    }
+    final loading = state is! ProviderLoaded && state is! ProviderError;
+    if (sameList && offline == _offline && loading == _loadingProviders) return;
+
+    final hadNone = _providers.isEmpty;
+    _adoptProviders(state);
+    // The stored scope can only be read once the list it refers to exists;
+    // before that a "these three sources" choice would prune away to nothing.
+    _scope = hadNone ? _initialScope(_providers) : _scope.pruned(_providers);
+    _railOrder = _orderedIds(_providers, _scope);
     setState(() {});
-    _controller.setProviderSet(_buildRefs(providers, _selectedIds));
+    _controller.setProviderSet(_refs());
   }
 
-  Set<String> _initialSelection(List<ProviderEntity> providers) {
-    final hive = getIt<HiveService>();
-    final existing = providers.map((p) => p.id).toSet();
-    var ids = hive.getCrossSearchProviders().where(existing.contains).toSet();
-    if (ids.isEmpty) {
-      ids = hive.getFavoriteProviders().where(existing.contains).toSet();
+  /// Every usable source, unless the user (or the caller) narrowed it.
+  ///
+  /// The old chain fell back to the favourites list and then to the single
+  /// "current" provider, so a user who had never opened the picker searched one
+  /// source and was told "Found in 0 of 1" — which reads as an empty internet
+  /// rather than as a scope of one.
+  CrossSearchScope _initialScope(List<ProviderEntity> providers) {
+    final requested = widget.initialProviderIds
+        ?.where((id) => providers.any((p) => p.id == id));
+    if (requested != null && requested.isNotEmpty) {
+      return CrossSearchScope.only(requested);
     }
-    if (ids.isEmpty) {
-      final current = hive.getCurrentProvider();
-      if (current.isNotEmpty && existing.contains(current)) ids = {current};
-    }
-    return ids;
+    final stored =
+        CrossSearchScope.fromStored(getIt<HiveService>().getCrossSearchProviders());
+    return providers.isEmpty ? stored : stored.pruned(providers);
   }
 
-  List<ProviderRef> _buildRefs(List<ProviderEntity> providers, Set<String> ids) {
-    return providers
-        .where((p) => ids.contains(p.id))
-        .map(ProviderRef.fromEntity)
-        .toList();
+  List<String> _orderedIds(List<ProviderEntity> providers, CrossSearchScope scope) {
+    final selected = <String>[];
+    final rest = <String>[];
+    for (final p in providers) {
+      (!scope.isAll && scope.includes(p.id) ? selected : rest).add(p.id);
+    }
+    return [...selected, ...rest];
+  }
+
+  List<ProviderRef> _refs() =>
+      _scope.resolve(_providers).map(ProviderRef.fromEntity).toList();
+
+  void _applyScope(CrossSearchScope scope, {bool reorder = false}) {
+    if (scope == _scope) return;
+    _scope = scope;
+    if (reorder) _railOrder = _orderedIds(_providers, scope);
+    unawaited(getIt<HiveService>().setCrossSearchProviders(scope.toStored()));
+    setState(() {});
+    _controller.setProviderSet(_refs());
   }
 
   Future<void> _openSetSheet() async {
     final result = await SearchSetSheet.show(
       context,
       providers: _providers,
-      initialSelected: _selectedIds,
+      scope: _scope,
     );
     if (result == null || !mounted) return;
-    _selectedIds = result;
-    await getIt<HiveService>().setCrossSearchProviders(result.toList());
-    _controller.setProviderSet(_buildRefs(_providers, result));
-    setState(() {});
+    _applyScope(result, reorder: true);
   }
 
   void _openDetail(MergedSearchTitle title) {
@@ -220,7 +260,17 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _searchField(),
-            _sourcesBar(),
+            SourceScopeBar(
+              providers: _providers,
+              order: _railOrder,
+              scope: _scope,
+              loading: _loadingProviders && _providers.isEmpty,
+              onToggle: (id) => _applyScope(_scope.toggle(id)),
+              onSelectAll: () =>
+                  _applyScope(const CrossSearchScope.all(), reorder: true),
+              onOpenPicker: _openSetSheet,
+            ),
+            const SizedBox(height: 10),
             const Divider(height: 1, color: Colors.white10),
             Expanded(
               child: AnimatedBuilder(
@@ -278,60 +328,34 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
     );
   }
 
-  Widget _sourcesBar() {
-    final label = _selectedIds.isEmpty
-        ? 'search.no_sources_selected'.tr()
-        : 'search.sources_selected'.tr(args: ['${_selectedIds.length}']);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
-      child: Material(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(10),
-        child: InkWell(
-          onTap: _openSetSheet,
-          borderRadius: BorderRadius.circular(10),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            child: Row(
-              children: [
-                const Icon(Icons.tune, size: 16, color: AppColors.primary),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    label,
-                    maxLines: 1,
-                    softWrap: false,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                        color: AppColors.textSecondary, fontSize: 13),
-                  ),
-                ),
-                const Icon(Icons.chevron_right_rounded,
-                    size: 18, color: AppColors.textHint),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
   Widget _body() {
-    if (_selectedIds.isEmpty) {
-      return _centered(
-        icon: Icons.tune,
-        text: 'search.pick_sources'.tr(),
-        action: FilledButton(
-          onPressed: _openSetSheet,
-          child: Text('search.choose_sources'.tr()),
-        ),
-      );
+    if (_providers.isEmpty) {
+      return _loadingProviders
+          ? _centered(
+              icon: Icons.travel_explore,
+              text: 'search.loading_sources'.tr(),
+              action: const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          : _centered(
+              icon: Icons.tune,
+              text: 'search.no_sources_available'.tr(),
+            );
     }
     if (_controller.query.isEmpty) {
       return _centered(
         icon: Icons.travel_explore,
         text: 'search.type_to_search_n'
             .tr(args: ['${_controller.expectedLegs}']),
+      );
+    }
+    if (_controller.awaitingLongerQuery) {
+      return _centered(
+        icon: Icons.keyboard,
+        text: 'search.min_query_n'.tr(args: ['${SearchQueryPolicy.minLength}']),
       );
     }
 
@@ -345,13 +369,7 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
         if (_offline)
           SliverToBoxAdapter(child: _note('search.offline_note'.tr())),
         if (merged.isEmpty && done)
-          SliverToBoxAdapter(
-            child: _centered(
-              icon: Icons.search_off,
-              text: 'search.no_results_any'.tr(),
-              padded: false,
-            ),
-          )
+          SliverToBoxAdapter(child: _emptyResults())
         else if (_grouped)
           SliverList(
             delegate: SliverChildBuilderDelegate(
@@ -411,41 +429,138 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
     );
   }
 
+  /// Progress first, then one pill per outcome.
+  ///
+  /// The old single line collapsed four outcomes into "found in X of Y", so a
+  /// source that crashed, a source that timed out and a source that genuinely
+  /// had nothing were all reported as the same missing Y.
   Widget _summary() {
-    final pending = _controller.pendingSources;
-    final searching = _controller.searching;
-    final text = searching
-        ? (pending.isEmpty
+    final c = _controller;
+    final headline = c.searching
+        ? (c.pendingSources.isEmpty
             ? 'search.searching'.tr()
-            : 'search.waiting_for'.tr(args: [pending.take(2).join(', ')]))
+            : 'search.waiting_for'.tr(args: [c.pendingSources.take(2).join(', ')]))
         : 'search.found_in'.tr(args: [
-            '${_controller.sourcesWithResults}',
-            '${_controller.expectedLegs}',
+            '${c.sourcesWithResults}',
+            '${c.expectedLegs}',
           ]);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (searching) ...[
-            const SizedBox(
-              width: 14,
-              height: 14,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-            const SizedBox(width: 8),
-          ],
-          Expanded(
-            child: Text(
-              '$text · ${'search.results_n'.tr(args: ['${_controller.totalItems}'])}',
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                  color: AppColors.textSecondary, fontSize: 12.5),
-            ),
+          Row(
+            children: [
+              if (c.searching) ...[
+                const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 8),
+              ],
+              Expanded(
+                child: Text(
+                  '$headline · ${'search.results_n'.tr(args: ['${c.totalItems}'])}',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                      color: AppColors.textSecondary, fontSize: 12.5),
+                ),
+              ),
+              if (c.failedLegs.isNotEmpty && !c.searching)
+                TextButton(
+                  onPressed: _controller.retryFailed,
+                  style: TextButton.styleFrom(
+                    visualDensity: VisualDensity.compact,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                  ),
+                  child: Text('search.retry_failed'.tr()),
+                ),
+            ],
           ),
+          _statusPills(c),
         ],
       ),
+    );
+  }
+
+  Widget _statusPills(CrossSearchController c) {
+    final pills = <Widget>[
+      if (c.runningSources > 0)
+        _pill('search.status_searching_n'.tr(args: ['${c.runningSources}']),
+            AppColors.textSecondary),
+      if (c.sourcesWithResults > 0)
+        _pill('search.status_with_results_n'.tr(args: ['${c.sourcesWithResults}']),
+            AppColors.success),
+      if (c.emptySources > 0)
+        _pill('search.status_no_match_n'.tr(args: ['${c.emptySources}']),
+            AppColors.textHint),
+      if (c.timedOutSources > 0)
+        _pill('search.status_timed_out_n'.tr(args: ['${c.timedOutSources}']),
+            Colors.orange),
+      if (c.erroredSources > 0)
+        _pill('search.status_failed_n'.tr(args: ['${c.erroredSources}']),
+            AppColors.error),
+    ];
+    if (pills.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Wrap(spacing: 6, runSpacing: 6, children: pills),
+    );
+  }
+
+  Widget _pill(String text, Color color) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.14),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text(text,
+            style: TextStyle(
+                color: color, fontSize: 11, fontWeight: FontWeight.w600)),
+      );
+
+  /// Nothing to show — but *why* nothing decides what the user should do next.
+  Widget _emptyResults() {
+    final c = _controller;
+    final broken = c.brokenSources;
+    final String text;
+    if (c.everySourceBroken) {
+      text = broken == 1
+          ? 'search.all_sources_failed_one'.tr()
+          : 'search.all_sources_failed'.tr(args: ['$broken']);
+    } else if (broken > 0) {
+      text = 'search.no_results_with_failures'
+          .tr(args: ['${c.emptySources}', '$broken']);
+    } else {
+      text = 'search.no_results_any'.tr();
+    }
+
+    // Both offers can apply at once: a narrowed search whose only source broke
+    // is exactly the case the user reads as "the app found nothing".
+    final buttons = <Widget>[
+      if (broken > 0)
+        FilledButton.tonal(
+          onPressed: c.retryFailed,
+          child: Text('search.retry_failed'.tr()),
+        ),
+      if (!_scope.isAll)
+        FilledButton(
+          onPressed: () =>
+              _applyScope(const CrossSearchScope.all(), reorder: true),
+          child: Text('search.search_all_sources'.tr()),
+        ),
+    ];
+
+    return _centered(
+      icon: broken > 0 ? Icons.cloud_off : Icons.search_off,
+      text: text,
+      action: buttons.isEmpty
+          ? null
+          : Wrap(spacing: 10, runSpacing: 8, children: buttons),
+      padded: false,
     );
   }
 
@@ -512,17 +627,35 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
   /// Every leg by name with what it did, and a Retry for the ones that failed.
   Widget _sourceStatusList() {
     final legs = _controller.results;
-    if (legs.isEmpty) return const SizedBox.shrink();
+    final pending = _controller.pendingSources;
+    if (legs.isEmpty && pending.isEmpty) return const SizedBox.shrink();
+    final hasFailures = _controller.failedLegs.isNotEmpty;
+    final open = _statusOpen || hasFailures;
     return Theme(
       data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
       child: ExpansionTile(
-        initiallyExpanded: _controller.failedLegs.isNotEmpty,
+        // ExpansionTile reads initiallyExpanded once, at mount. A leg that
+        // fails after the first build would otherwise leave the tile collapsed
+        // over rows that were built and never shown — the failure detail
+        // present in the tree and invisible on screen.
+        key: ValueKey('src-status-$hasFailures'),
+        initiallyExpanded: open,
+        onExpansionChanged: (v) => setState(() => _statusOpen = v),
         tilePadding: const EdgeInsets.symmetric(horizontal: 16),
         title: Text(
           'search.sources'.tr(),
           style: const TextStyle(color: AppColors.textSecondary, fontSize: 13),
         ),
-        children: [
+        children: open ? _statusRows(legs, pending) : const [],
+      ),
+    );
+  }
+
+  List<Widget> _statusRows(
+    List<ProviderSearchResult> legs,
+    List<String> pending,
+  ) {
+    return [
           for (final leg in legs)
             ListTile(
               dense: true,
@@ -535,9 +668,10 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
                 _statusLabel(leg),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(color: AppColors.textHint, fontSize: 11.5),
+                style: TextStyle(color: _statusColor(leg), fontSize: 11.5),
               ),
-              trailing: leg.status == ProviderSearchStatus.ok
+              trailing: leg.status == ProviderSearchStatus.ok ||
+                      leg.status == ProviderSearchStatus.empty
                   ? null
                   : _controller.isRetrying(leg.provider.id)
                       ? const SizedBox(
@@ -551,9 +685,26 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
                           child: Text('general.retry'.tr()),
                         ),
             ),
-        ],
-      ),
-    );
+          // Legs that have not answered are listed too: an absent row is what
+          // made a still-running source look like a source with no results.
+          for (final name in pending)
+            ListTile(
+              dense: true,
+              contentPadding: const EdgeInsets.only(left: 16, right: 8),
+              title: Text(name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Colors.white, fontSize: 13)),
+              subtitle: Text('search.status_searching'.tr(),
+                  style: const TextStyle(
+                      color: AppColors.textSecondary, fontSize: 11.5)),
+              trailing: const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+    ];
   }
 
   String _statusLabel(ProviderSearchResult leg) => switch (leg.status) {
@@ -564,6 +715,13 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
         ProviderSearchStatus.error => leg.message.isEmpty
             ? 'search.source_failed'.tr()
             : leg.message,
+      };
+
+  Color _statusColor(ProviderSearchResult leg) => switch (leg.status) {
+        ProviderSearchStatus.ok => AppColors.success,
+        ProviderSearchStatus.empty => AppColors.textHint,
+        ProviderSearchStatus.timeout => Colors.orange,
+        ProviderSearchStatus.error => AppColors.error,
       };
 
   Widget _note(String text) => Container(
@@ -604,4 +762,16 @@ class _CrossSearchPageState extends State<CrossSearchPage> {
       child: Padding(padding: const EdgeInsets.all(32), child: content),
     );
   }
+}
+
+/// What to search, and where.
+///
+/// A record rather than more positional route arguments: `/cross-search` is
+/// pushed from several screens and a bare String had no room for the source a
+/// caller already decided on.
+class CrossSearchRequest {
+  const CrossSearchRequest({required this.query, this.providerIds});
+
+  final String query;
+  final Set<String>? providerIds;
 }

--- a/lib/features/search/presentation/widgets/search_set_sheet.dart
+++ b/lib/features/search/presentation/widgets/search_set_sheet.dart
@@ -3,35 +3,34 @@ import 'package:flutter/material.dart';
 
 import 'package:soplay/core/theme/app_colors.dart';
 import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
+import 'package:soplay/features/search/domain/entities/cross_search_scope.dart';
 
-/// Multi-select for the cross-search provider set. Returns the chosen ids via
-/// `Navigator.pop(context, Set<String>)`, or `null` if dismissed.
+/// The full source list, for narrowing when the chip rail on the page is not
+/// enough — a couple of hundred providers need a filter box.
 ///
-/// Kept deliberately explicit: with 200+ installed providers, searching all
-/// would be slow, so the user curates a small set here.
+/// Returns a [CrossSearchScope] via `Navigator.pop`, or `null` if dismissed.
+/// Selecting nothing is not "search nothing": it resolves back to every source,
+/// which is the default this feature is supposed to have.
 class SearchSetSheet extends StatefulWidget {
   const SearchSetSheet({
     super.key,
     required this.providers,
-    required this.initialSelected,
+    required this.scope,
   });
 
   final List<ProviderEntity> providers;
-  final Set<String> initialSelected;
+  final CrossSearchScope scope;
 
-  static Future<Set<String>?> show(
+  static Future<CrossSearchScope?> show(
     BuildContext context, {
     required List<ProviderEntity> providers,
-    required Set<String> initialSelected,
+    required CrossSearchScope scope,
   }) {
-    return showModalBottomSheet<Set<String>>(
+    return showModalBottomSheet<CrossSearchScope>(
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,
-      builder: (_) => SearchSetSheet(
-        providers: providers,
-        initialSelected: initialSelected,
-      ),
+      builder: (_) => SearchSetSheet(providers: providers, scope: scope),
     );
   }
 
@@ -40,8 +39,15 @@ class SearchSetSheet extends StatefulWidget {
 }
 
 class _SearchSetSheetState extends State<SearchSetSheet> {
-  late final Set<String> _selected = {...widget.initialSelected};
+  late final Set<String> _selected = {
+    if (!widget.scope.isAll) ...widget.scope.ids!,
+  };
   String _query = '';
+
+  bool get _isAll => _selected.isEmpty || _selected.length == widget.providers.length;
+
+  CrossSearchScope get _result =>
+      _isAll ? const CrossSearchScope.all() : CrossSearchScope.only(_selected);
 
   static const int _softCap = 15;
 
@@ -66,7 +72,8 @@ class _SearchSetSheetState extends State<SearchSetSheet> {
   Widget build(BuildContext context) {
     final bottom = MediaQuery.viewInsetsOf(context).bottom;
     final items = _filtered;
-    final overCap = _selected.length > _softCap;
+    final effective = _isAll ? widget.providers.length : _selected.length;
+    final overCap = effective > _softCap;
 
     return Padding(
       padding: EdgeInsets.only(bottom: bottom),
@@ -104,18 +111,22 @@ class _SearchSetSheetState extends State<SearchSetSheet> {
                                   color: AppColors.textPrimary,
                                   fontSize: 18,
                                   fontWeight: FontWeight.w800)),
-                          Text('search.selected_n'
-                              .tr(args: ['${_selected.length}']),
+                          Text(
+                              _isAll
+                                  ? 'search.all_sources_n'
+                                      .tr(args: ['${widget.providers.length}'])
+                                  : 'search.selected_n_of_m'.tr(args: [
+                                      '${_selected.length}',
+                                      '${widget.providers.length}',
+                                    ]),
                               style: const TextStyle(
                                   color: AppColors.textHint, fontSize: 12)),
                         ],
                       ),
                     ),
                     TextButton(
-                      onPressed: _selected.isEmpty
-                          ? null
-                          : () => setState(_selected.clear),
-                      child: Text('search.clear_filter'.tr()),
+                      onPressed: _isAll ? null : () => setState(_selected.clear),
+                      child: Text('search.select_all_sources'.tr()),
                     ),
                   ],
                 ),
@@ -151,8 +162,7 @@ class _SearchSetSheetState extends State<SearchSetSheet> {
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
-                    'search.many_sources_warning'
-                        .tr(args: ['${_selected.length}']),
+                    'search.many_sources_warning'.tr(args: ['$effective']),
                     style: const TextStyle(
                         color: Colors.orange, fontSize: 11.5, height: 1.3),
                   ),
@@ -164,14 +174,22 @@ class _SearchSetSheetState extends State<SearchSetSheet> {
                   itemCount: items.length,
                   itemBuilder: (_, i) {
                     final p = items[i];
-                    final on = _selected.contains(p.id);
+                    final on = _isAll || _selected.contains(p.id);
                     return CheckboxListTile(
                       value: on,
                       dense: true,
                       controlAffinity: ListTileControlAffinity.leading,
                       activeColor: AppColors.primary,
                       onChanged: (_) => setState(() {
-                        if (on) {
+                        // Unchecking a row while every source is in scope has
+                        // to materialise the full set first, or it would read
+                        // as a no-op.
+                        if (_isAll) {
+                          _selected
+                            ..clear()
+                            ..addAll(widget.providers.map((e) => e.id))
+                            ..remove(p.id);
+                        } else if (on) {
                           _selected.remove(p.id);
                         } else {
                           _selected.add(p.id);
@@ -215,9 +233,10 @@ class _SearchSetSheetState extends State<SearchSetSheet> {
                     child: FilledButton(
                       style: FilledButton.styleFrom(
                           backgroundColor: AppColors.primary),
-                      onPressed: () => Navigator.of(context).pop(_selected),
-                      child: Text('search.apply_n'
-                          .tr(args: ['${_selected.length}'])),
+                      onPressed: () => Navigator.of(context).pop(_result),
+                      child: Text(_isAll
+                          ? 'search.apply_all'.tr()
+                          : 'search.apply_n'.tr(args: ['${_selected.length}'])),
                     ),
                   ),
                 ),

--- a/lib/features/search/presentation/widgets/source_scope_bar.dart
+++ b/lib/features/search/presentation/widgets/source_scope_bar.dart
@@ -1,0 +1,150 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import 'package:soplay/core/theme/app_colors.dart';
+import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
+import 'package:soplay/features/search/domain/entities/cross_search_scope.dart';
+
+/// The scope control for all-source search: a scrolling rail of source chips
+/// with "All sources" pinned at the front.
+///
+/// A rail rather than a dropdown or the old bottom sheet, because the two
+/// things that matter here — *what is being searched right now* and *changing
+/// it* — both have to be on screen. A menu shows neither until it is opened,
+/// and the sheet it replaces reported the whole selection as the string
+/// "1 selected", which is how a user searched one source without noticing.
+/// The full list still lives one tap away behind the last chip; a rail is a
+/// bad way to pick from two hundred sources, and a good way to see and undo
+/// the handful you actually narrowed to.
+class SourceScopeBar extends StatelessWidget {
+  const SourceScopeBar({
+    super.key,
+    required this.providers,
+    required this.order,
+    required this.scope,
+    required this.onToggle,
+    required this.onSelectAll,
+    required this.onOpenPicker,
+    this.loading = false,
+  });
+
+  final List<ProviderEntity> providers;
+
+  /// Chip order, held by the page so a chip never moves out from under the
+  /// finger that just toggled it.
+  final List<String> order;
+
+  final CrossSearchScope scope;
+  final ValueChanged<String> onToggle;
+  final VoidCallback onSelectAll;
+  final VoidCallback onOpenPicker;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    final byId = {for (final p in providers) p.id: p};
+    final ids = [for (final id in order) if (byId.containsKey(id)) id];
+
+    return SizedBox(
+      height: 40,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(width: 16),
+          // Outside the scroll view, not merely first in it: "widen back to
+          // everything" has to stay one tap away after the user has scrolled
+          // the rail, which is exactly when a narrowed search looks broken.
+          _Chip(
+            label: loading
+                ? 'search.loading_sources'.tr()
+                : 'search.all_sources_n'.tr(args: ['${providers.length}']),
+            selected: scope.isAll,
+            icon: Icons.travel_explore,
+            onTap: loading ? null : onSelectAll,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.only(right: 16),
+              itemCount: ids.length + 1,
+              separatorBuilder: (_, _) => const SizedBox(width: 8),
+              itemBuilder: (_, i) {
+                if (i == ids.length) {
+                  return _Chip(
+                    label: 'search.more_sources'.tr(),
+                    selected: false,
+                    icon: Icons.tune,
+                    onTap: loading ? null : onOpenPicker,
+                  );
+                }
+                final p = byId[ids[i]]!;
+                // In "all" mode no individual chip reads as picked, so a tap on
+                // one narrows to it instead of subtracting it from everything.
+                final on = !scope.isAll && scope.includes(p.id);
+                return _Chip(
+                  label: p.name,
+                  selected: on,
+                  icon: on ? Icons.check : null,
+                  onTap: () => onToggle(p.id),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.icon,
+  });
+
+  final String label;
+  final bool selected;
+  final IconData? icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = selected ? Colors.white : AppColors.textSecondary;
+    return Material(
+      color: selected ? AppColors.primary : AppColors.surface,
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 15, color: fg),
+                const SizedBox(width: 6),
+              ],
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 160),
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: fg,
+                    fontSize: 13,
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/user_lists/presentation/pages/user_lists_page.dart
+++ b/lib/features/user_lists/presentation/pages/user_lists_page.dart
@@ -1,7 +1,11 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:soplay/core/di/injection.dart';
 import 'package:soplay/core/theme/app_colors.dart';
 import 'package:soplay/core/widgets/app_tab_bar.dart';
+import 'package:soplay/features/detail/domain/entities/detail_args.dart';
+import 'package:soplay/features/home/presentation/widgets/home_shared_widgets.dart';
 import 'package:soplay/features/my_list/domain/entities/favorite_entity.dart';
 import 'package:soplay/features/user_lists/domain/entities/user_list_kind.dart';
 import 'package:soplay/features/user_lists/domain/repositories/user_lists_repository.dart';
@@ -50,15 +54,15 @@ class _UserListsPageState extends State<UserListsPage>
         scrolledUnderElevation: 0,
         elevation: 0,
         titleSpacing: 16,
-        title: const Text(
-          'My Lists',
-          style: TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
+        title: Text(
+          'user_lists.title'.tr(),
+          style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
         ),
         bottom: AppTabBar(
           // Two tabs: split the bar rather than hugging the left edge.
           isScrollable: false,
           controller: _tabs,
-          labels: [for (final k in _kinds) k.label],
+          labels: [for (final k in _kinds) _labelOf(k)],
         ),
       ),
       body: TabBarView(
@@ -68,6 +72,13 @@ class _UserListsPageState extends State<UserListsPage>
     );
   }
 }
+
+/// The enum's own `label` is an English developer-facing name; the tabs and
+/// headings the user reads come from the same keys the detail page uses.
+String _labelOf(UserListKind kind) => switch (kind) {
+  UserListKind.watchLater => 'detail.watch_later'.tr(),
+  UserListKind.watched => 'detail.watched'.tr(),
+};
 
 class _UserListTab extends StatefulWidget {
   const _UserListTab({required this.kind});
@@ -80,94 +91,202 @@ class _UserListTab extends StatefulWidget {
 
 class _UserListTabState extends State<_UserListTab>
     with AutomaticKeepAliveClientMixin {
-  late Future<List<FavoriteEntity>> _future = _load();
+  List<FavoriteEntity>? _items;
 
   @override
   bool get wantKeepAlive => true;
 
-  Future<List<FavoriteEntity>> _load() async {
-    final result = await getIt<UserListsRepository>().getList(widget.kind);
-    return result.getOrNull() ?? const [];
+  @override
+  void initState() {
+    super.initState();
+    _load();
   }
 
-  Future<void> _refresh() async {
-    setState(() => _future = _load());
-    await _future;
+  /// Refreshing keeps the rows on screen: replacing them with a spinner while
+  /// the pull-to-refresh indicator is already spinning blanks the whole tab.
+  Future<void> _load() async {
+    final result = await getIt<UserListsRepository>().getList(widget.kind);
+    if (!mounted) return;
+    setState(() => _items = result.getOrNull() ?? const []);
   }
 
   Future<void> _remove(FavoriteEntity item) async {
+    setState(
+      () => _items = [
+        for (final e in _items ?? const <FavoriteEntity>[])
+          if (e.contentUrl != item.contentUrl) e,
+      ],
+    );
     await getIt<UserListsRepository>().remove(widget.kind, item.contentUrl);
-    await _refresh();
+  }
+
+  void _open(FavoriteEntity item) {
+    context.push(
+      '/detail',
+      extra: DetailArgs(contentUrl: item.contentUrl, provider: item.provider),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return FutureBuilder<List<FavoriteEntity>>(
-      future: _future,
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
-        }
-        final items = snapshot.data ?? const <FavoriteEntity>[];
-        if (items.isEmpty) {
-          // The repository never surfaces an error — a failed fetch falls back
-          // to the cache — so "empty" is the only empty-ish state there is.
-          return RefreshIndicator(
-            onRefresh: _refresh,
-            child: ListView(
+    final items = _items;
+    if (items == null) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.primary),
+      );
+    }
+
+    return RefreshIndicator(
+      color: AppColors.primary,
+      backgroundColor: AppColors.surface,
+      onRefresh: _load,
+      child: items.isEmpty
+          ? const _EmptyState()
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: items.length,
+              separatorBuilder: (_, _) =>
+                  const Divider(color: AppColors.divider, height: 1, indent: 84),
+              itemBuilder: (context, i) {
+                final item = items[i];
+                return _UserListRow(
+                  item: item,
+                  onTap: () => _open(item),
+                  onRemove: () => _remove(item),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _UserListRow extends StatelessWidget {
+  const _UserListRow({
+    required this.item,
+    required this.onTap,
+    required this.onRemove,
+  });
+
+  final FavoriteEntity item;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          children: [
+            // Fixed box: the thumbnail loads late, and letting it size the row
+            // makes the whole list jump as images arrive.
+            SizedBox(
+              width: 54,
+              height: 76,
+              child: HomeNetworkImage(
+                url: item.thumbnail,
+                borderRadius: BorderRadius.circular(8),
+                placeholderIcon: Icons.movie_outlined,
+              ),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    item.title.trim().isEmpty
+                        ? 'my_list.untitled'.tr()
+                        : item.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    item.provider,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              tooltip: 'user_lists.remove'.tr(),
+              icon: const Icon(
+                Icons.close_rounded,
+                color: AppColors.textHint,
+                size: 20,
+              ),
+              onPressed: onRemove,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    // Scrollable so the empty tab still answers a pull-to-refresh.
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const SizedBox(height: 120),
-                Center(
-                  child: Text(
-                    'Nothing in ${widget.kind.label} yet',
-                    style: const TextStyle(color: Colors.white70),
+                const Icon(
+                  Icons.playlist_add_check_rounded,
+                  color: AppColors.textHint,
+                  size: 52,
+                ),
+                const SizedBox(height: 14),
+                Text(
+                  'user_lists.empty_title'.tr(),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'user_lists.empty_subtitle'.tr(),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textHint,
+                    fontSize: 13,
+                    height: 1.4,
                   ),
                 ),
               ],
             ),
-          );
-        }
-        return RefreshIndicator(
-          onRefresh: _refresh,
-          child: ListView.separated(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            itemCount: items.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (context, i) {
-              final item = items[i];
-              return ListTile(
-                leading: item.thumbnail.isEmpty
-                    ? const SizedBox(width: 44)
-                    : ClipRRect(
-                        borderRadius: BorderRadius.circular(6),
-                        child: Image.network(
-                          item.thumbnail,
-                          width: 44,
-                          height: 62,
-                          fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => const SizedBox(width: 44),
-                        ),
-                      ),
-                title: Text(
-                  item.title.isEmpty ? item.contentUrl : item.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(color: Colors.white),
-                ),
-                subtitle: Text(
-                  item.provider,
-                  style: const TextStyle(color: Colors.white54, fontSize: 12),
-                ),
-                trailing: IconButton(
-                  icon: const Icon(Icons.close_rounded, color: Colors.white54),
-                  onPressed: () => _remove(item),
-                ),
-              );
-            },
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/test/features/search/cross_search_scope_test.dart
+++ b/test/features/search/cross_search_scope_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soplay/features/profile/domain/entities/provider_entity.dart';
+import 'package:soplay/features/search/domain/entities/cross_search_scope.dart';
+
+ProviderEntity _p(String id) => ProviderEntity(
+      id: id,
+      name: id,
+      image: '',
+      url: '',
+      description: '',
+      domains: const [],
+    );
+
+void main() {
+  final providers = [_p('a'), _p('b'), _p('c')];
+
+  group('default scope', () {
+    test('a user who never opened the picker searches every source', () {
+      final scope = CrossSearchScope.fromStored(const []);
+      expect(scope.isAll, isTrue);
+      expect(scope.resolve(providers).length, 3);
+    });
+
+    test('an empty narrowing is all, not a search with no legs', () {
+      expect(CrossSearchScope.only(const <String>[]).isAll, isTrue);
+      expect(
+        CrossSearchScope.only({'a'}).toggle('a').isAll,
+        isTrue,
+        reason: 'toggling the last source off widens back to all',
+      );
+    });
+  });
+
+  group('pruning', () {
+    test('uninstalled ids are dropped', () {
+      final scope = CrossSearchScope.only({'a', 'gone'}).pruned(providers);
+      expect(scope.ids, {'a'});
+    });
+
+    test('pruning everything away widens back to all', () {
+      expect(CrossSearchScope.only({'gone'}).pruned(providers).isAll, isTrue);
+    });
+
+    test('a stored set naming every source is all, so later installs count',
+        () {
+      final stored = CrossSearchScope.fromStored(const ['a', 'b', 'c']);
+      final scope = stored.pruned(providers);
+      expect(scope.isAll, isTrue);
+      expect(scope.resolve([...providers, _p('d')]).length, 4);
+    });
+  });
+
+  group('toggling from all', () {
+    test('a tap narrows to that one source rather than excluding it', () {
+      final scope = const CrossSearchScope.all().toggle('b');
+      expect(scope.ids, {'b'});
+    });
+  });
+
+  test('round-trips through storage', () {
+    final scope = CrossSearchScope.only({'a', 'c'});
+    expect(CrossSearchScope.fromStored(scope.toStored()), scope);
+    expect(
+      CrossSearchScope.fromStored(const CrossSearchScope.all().toStored()).isAll,
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## Mangayomi extensions

Four defects on one request path, which together meant no extension worked:

- The extension `Dio` carried **no headers at all**, so every request went out as `Dart/3.x (dart:io)`. Cloudflare refuses that outright — a source was blocked before its own code ran.
- The Cloudflare retry solved the challenge as Chrome/125, then replayed with the request's original headers. Clearance is bound to the agent that earned it, so the replay was rejected — and with no third attempt the challenge HTML went to the extension as if it were the page.
- A managed challenge is routinely served as **200 or 429**, but the sniff only ran on 403/503.
- `_seedPrefs` promised extension defaults and only registered the pref store, leaving the domain keys extensions read their base URL from unset.

None of it was visible: with `validateStatus` accepting everything, a refusal never threw, the extension parsed the block page, found nothing, and the source reported "no results". Refusals are now remembered by the fetcher and reported when a call comes back empty, so a blocked source reads as blocked.

Two requests still went out under their own agents — the poster loader on Chrome/124, the player on Chrome/120. Both now share the one constant.

## Nothing hangs on a source any more

Neither JS runtime bounded anything, so a source that never replied left whatever screen was loading it on its skeleton forever. The Mangayomi runtime made it worse: every call queues behind one gate, so a single hung call held every later call behind it. The bound goes inside the lock, where it releases the gate as well as the caller.

## All-source search

"Found in 0 of 1 sources · 0 results" was two bugs wearing one sentence.

The scope defaulted through favourites to the current provider, so a user who had never opened the picker searched exactly one source and the page called that a fan-out. Scope is now either *all* or an explicit narrowing — never a frozen id set, so a source installed tomorrow is searched tomorrow.

The second bug is that a source which failed and a source which had no match rendered identically. The distinction existed all the way from the engine and was discarded in the summary. Each outcome now has its own pill, and the empty state says "all N sources failed to answer, this is not an empty result" when that is what happened.

The picker moves from a bottom sheet onto a chip rail under the field: the two things that matter are what is being searched right now and changing it, and a sheet shows neither until it is opened. Failed runs are also no longer cached for five minutes — replaying a failure is the opposite of what retyping the query means.

## Interface

Skeletons whose geometry did not match what replaced them, so the feed jumped when data arrived; rails whose posters resolved to different heights depending on caption length; tap targets the height of their text rather than of a finger; error views that accepted a message and never showed it; a hero that advanced on its timer mid-drag; and a shimmer with eleven levels of contrast, which on a dark panel reads as a frozen screen.

---

`flutter analyze` clean (one pre-existing info), 53 tests pass, all 810 translation keys resolve in en/ru/uz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)