### PR TITLE
Bring Live TV out of the profile

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -418,7 +418,8 @@
     "following": "Following",
     "premiere": "Premiere",
     "buff": "Buff",
-    "anilist": "AniList"
+    "anilist": "AniList",
+    "live_tv": "Live TV"
   },
   "premiere": {
     "tab_title": "Premieres",
@@ -1086,7 +1087,8 @@
     "no_match": "No channel matches that.",
     "empty": "No channels yet.",
     "load_failed": "Couldn't load the channels.",
-    "retry": "Try again"
+    "retry": "Try again",
+    "recent": "RECENTLY WATCHED"
   },
   "time": {
     "now": "just now",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -472,7 +472,8 @@
     "following": "Отслеживаемые",
     "premiere": "Премьеры",
     "buff": "Buff",
-    "anilist": "AniList"
+    "anilist": "AniList",
+    "live_tv": "Эфир"
   },
   "premiere": {
     "tab_title": "Премьеры",
@@ -1086,7 +1087,8 @@
     "no_match": "Ничего не найдено.",
     "empty": "Каналов пока нет.",
     "load_failed": "Не удалось загрузить каналы.",
-    "retry": "Повторить"
+    "retry": "Повторить",
+    "recent": "НЕДАВНО СМОТРЕЛИ"
   },
   "time": {
     "now": "только что",

--- a/assets/translations/uz.json
+++ b/assets/translations/uz.json
@@ -418,7 +418,8 @@
     "following": "Kuzatilgan",
     "premiere": "Premyeralar",
     "buff": "Buff",
-    "anilist": "AniList"
+    "anilist": "AniList",
+    "live_tv": "Jonli TV"
   },
   "premiere": {
     "tab_title": "Premyeralar",
@@ -1086,7 +1087,8 @@
     "no_match": "Mos kanal topilmadi.",
     "empty": "Hozircha kanal yo‘q.",
     "load_failed": "Kanallarni yuklab bo‘lmadi.",
-    "retry": "Qayta urinish"
+    "retry": "Qayta urinish",
+    "recent": "YAQINDA KO‘RILGAN"
   },
   "time": {
     "now": "hozirgina",

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -44,6 +44,7 @@ class AppConstants {
   static const String languageKey = 'language';
   static const String currentProviderKey = 'current_provider';
   static const String liveTvFavouritesKey = 'live_tv_favourites';
+  static const String liveTvRecentKey = 'live_tv_recent';
   static const String airingRemindersKey = 'anilist_airing_reminders';
   static const String airingReminderCountKey = 'anilist_airing_reminder_count';
 

--- a/lib/core/navigation/app_tab.dart
+++ b/lib/core/navigation/app_tab.dart
@@ -10,11 +10,12 @@ import 'package:soplay/features/download/presentation/pages/downloads_page.dart'
 import 'package:soplay/features/history/presentation/pages/history_page.dart';
 import 'package:soplay/features/tracker/presentation/pages/following_page.dart';
 import 'package:soplay/features/trivia/presentation/pages/buff_hub_page.dart';
+import 'package:soplay/features/live_tv/presentation/pages/live_tv_page.dart';
 
 /// Stable, persisted key for every navigable tab. Add a value here + one
 /// registry entry + a `navigation.<name>` translation to introduce a new tab
 /// (Premiere, Buff, ...). `.name` is what gets stored in Hive.
-enum TabId { home, search, shorts, myList, profile, downloads, history, following, buff }
+enum TabId { home, search, shorts, myList, profile, downloads, history, following, buff, liveTv }
 
 /// Per-tab runtime state only the shell can supply. Shorts needs to know whether
 /// it is the visible tab (autoplay pause) and the refresh tick; every other
@@ -56,6 +57,7 @@ Widget _downloadsBuilder(TabBuildContext _) => const DownloadsPage();
 Widget _historyBuilder(TabBuildContext _) => const HistoryPage();
 Widget _followingBuilder(TabBuildContext _) => const FollowingPage();
 Widget _buffBuilder(TabBuildContext _) => const BuffHubPage();
+Widget _liveTvBuilder(TabBuildContext _) => const LiveTvPage(embedded: true);
 
 /// Single source of truth — replaces the old body list AND the metadata list.
 const Map<TabId, AppTabDef> kTabRegistry = {
@@ -117,6 +119,12 @@ const Map<TabId, AppTabDef> kTabRegistry = {
       activeIcon: CupertinoIcons.film_fill,
       labelKey: 'navigation.buff',
       builder: _buffBuilder),
+  TabId.liveTv: AppTabDef(
+      id: TabId.liveTv,
+      icon: CupertinoIcons.tv,
+      activeIcon: CupertinoIcons.tv_fill,
+      labelKey: 'navigation.live_tv',
+      builder: _liveTvBuilder),
 };
 
 /// Default = the current shipped 5-tab order → this IS the back-compat contract.

--- a/lib/core/storage/hive_service.dart
+++ b/lib/core/storage/hive_service.dart
@@ -372,6 +372,23 @@ class HiveService {
   Future<void> setLiveTvFavourites(List<String> ids) =>
       _settingsBox.put(AppConstants.liveTvFavouritesKey, ids);
 
+  /// The last channels watched, most recent first.
+  ///
+  /// Live TV is flipped through rather than browsed — you come back to the same
+  /// three or four channels — so where you were last is worth more here than a
+  /// catalogue is.
+  List<String> getLiveTvRecent() {
+    final raw = _settingsBox.get(AppConstants.liveTvRecentKey);
+    if (raw is! List) return const [];
+    return raw.map((e) => e.toString()).where((e) => e.isNotEmpty).toList();
+  }
+
+  /// Bounded: a history of everything ever watched is not a shortcut any more.
+  Future<void> pushLiveTvRecent(String id) {
+    final ids = [id, ...getLiveTvRecent().where((e) => e != id)].take(12).toList();
+    return _settingsBox.put(AppConstants.liveTvRecentKey, ids);
+  }
+
   bool get brightnessGestureEnabled {
     return _settingsBox.get(
           AppConstants.brightnessGestureKey,

--- a/lib/features/home/presentation/widgets/home_top_bar.dart
+++ b/lib/features/home/presentation/widgets/home_top_bar.dart
@@ -79,6 +79,13 @@ class HomeTopBar extends StatelessWidget {
             child: const AnilistLogo(size: 19, radius: 5),
             onTap: () => context.push('/anilist'),
           ),
+          // Live TV was reachable only through the profile, which is where
+          // things go to be forgotten. It is a line-up you open and leave, not
+          // a setting.
+          _TopBarIcon(
+            icon: Icons.live_tv_rounded,
+            onTap: () => context.push('/live-tv'),
+          ),
           _DownloadIndicator(),
           const _NotificationsIndicator(),
         ],

--- a/lib/features/live_tv/presentation/pages/live_tv_page.dart
+++ b/lib/features/live_tv/presentation/pages/live_tv_page.dart
@@ -15,7 +15,12 @@ import 'package:soplay/features/live_tv/data/live_tv_service.dart';
 /// screen is built for scanning — logo-forward cards, categories across the
 /// top, and the ones you actually watch pinned above everything else.
 class LiveTvPage extends StatefulWidget {
-  const LiveTvPage({super.key});
+  /// True when mounted as a tab rather than pushed: a tab is already at the
+  /// root of its stack, so it gets no back arrow and keeps its own bottom
+  /// padding clear of the nav bar.
+  const LiveTvPage({super.key, this.embedded = false});
+
+  final bool embedded;
 
   @override
   State<LiveTvPage> createState() => _LiveTvPageState();
@@ -27,6 +32,7 @@ class _LiveTvPageState extends State<LiveTvPage> {
 
   List<LiveCategory> _all = const [];
   Set<String> _favourites = <String>{};
+  List<String> _recent = const [];
   String _category = '';
   String _query = '';
   bool _loading = true;
@@ -36,6 +42,7 @@ class _LiveTvPageState extends State<LiveTvPage> {
   void initState() {
     super.initState();
     _favourites = _readFavourites();
+    _recent = getIt<HiveService>().getLiveTvRecent();
     _load();
   }
 
@@ -87,6 +94,10 @@ class _LiveTvPageState extends State<LiveTvPage> {
   }
 
   void _play(LiveChannel channel) {
+    getIt<HiveService>().pushLiveTvRecent(channel.id);
+    setState(() {
+      _recent = [channel.id, ..._recent.where((e) => e != channel.id)].take(12).toList();
+    });
     context.push(
       '/player',
       extra: PlayerArgs(
@@ -125,9 +136,18 @@ class _LiveTvPageState extends State<LiveTvPage> {
         surfaceTintColor: Colors.transparent,
         scrolledUnderElevation: 0,
         elevation: 0,
-        title: Text(
-          'live_tv.title'.tr(),
-          style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
+        automaticallyImplyLeading: !widget.embedded,
+        titleSpacing: widget.embedded ? 18 : null,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'live_tv.title'.tr(),
+              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(width: 8),
+            const _LivePill(),
+          ],
         ),
       ),
       body: SafeArea(child: _body()),
@@ -158,6 +178,15 @@ class _LiveTvPageState extends State<LiveTvPage> {
         .toList(growable: false);
     final showFavourites =
         favourites.isNotEmpty && _query.isEmpty && _category.isEmpty;
+
+    // Ordered by when it was watched, not by where it sits in the line-up, and
+    // never repeating what is already pinned right above it.
+    final byId = {for (final c in _flat) c.id: c};
+    final recent = [
+      for (final id in _recent)
+        if (byId[id] != null && !_favourites.contains(id)) byId[id]!,
+    ];
+    final showRecent = recent.isNotEmpty && _query.isEmpty && _category.isEmpty;
 
     return RefreshIndicator(
       color: AppColors.primary,
@@ -198,6 +227,14 @@ class _LiveTvPageState extends State<LiveTvPage> {
             ),
           ),
 
+          if (showRecent) ...[
+            _Header(label: 'live_tv.recent'.tr()),
+            _RecentRow(
+              channels: recent,
+              onPlay: _play,
+            ),
+          ],
+
           if (showFavourites) ...[
             _Header(label: 'live_tv.favourites'.tr()),
             _Grid(
@@ -228,8 +265,130 @@ class _LiveTvPageState extends State<LiveTvPage> {
             ),
           ],
 
-          const SliverToBoxAdapter(child: SizedBox(height: 28)),
+          SliverToBoxAdapter(child: SizedBox(height: widget.embedded ? 96 : 28)),
         ],
+      ),
+    );
+  }
+}
+
+/// The one thing that makes this screen read as live rather than as a grid of
+/// logos: it is on now, and there is nothing to resume to.
+class _LivePill extends StatelessWidget {
+  const _LivePill();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 5,
+            height: 5,
+            decoration: const BoxDecoration(
+              color: AppColors.primary,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 5),
+          Text(
+            'LIVE',
+            style: TextStyle(
+              fontSize: 9,
+              fontWeight: FontWeight.w900,
+              letterSpacing: 0.9,
+              color: AppColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The last few channels, as a rail rather than a grid.
+///
+/// A rail because this is a shortcut, not a section to browse: four or five
+/// entries wide is the whole of it, and it should never push the line-up itself
+/// off the first screen.
+class _RecentRow extends StatelessWidget {
+  const _RecentRow({required this.channels, required this.onPlay});
+
+  final List<LiveChannel> channels;
+  final ValueChanged<LiveChannel> onPlay;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: SizedBox(
+        height: 62,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 14),
+          itemCount: channels.length,
+          separatorBuilder: (_, _) => const SizedBox(width: 8),
+          itemBuilder: (context, i) {
+            final channel = channels[i];
+            return Material(
+              color: AppColors.card,
+              borderRadius: BorderRadius.circular(12),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                onTap: () => onPlay(channel),
+                child: Container(
+                  width: 148,
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.06)),
+                  ),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: 34,
+                        height: 34,
+                        child: channel.logoUrl == null
+                            ? Icon(
+                                Icons.live_tv_rounded,
+                                size: 18,
+                                color: AppColors.textHint,
+                              )
+                            : CachedNetworkImage(
+                                imageUrl: channel.logoUrl!,
+                                fit: BoxFit.contain,
+                                errorWidget: (_, _, _) => Icon(
+                                  Icons.live_tv_rounded,
+                                  size: 18,
+                                  color: AppColors.textHint,
+                                ),
+                              ),
+                      ),
+                      const SizedBox(width: 9),
+                      Expanded(
+                        child: Text(
+                          channel.name,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 11.5,
+                            height: 1.15,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Reachable

Live TV was four taps deep behind Profile, which is where things go to be forgotten. A line-up is something you open and leave, not a setting.

- **Home bar entry**, beside search and AniList.
- **A tab anyone can promote themselves** — `TabId.liveTv` joins the registry as an opt-in tab, so it can be dragged onto the bar in the customizer like Downloads or History. Mounted as a tab it drops the back arrow it would have nothing to go back to, and leaves room under the nav capsule.

## Recently watched

Live TV is *flipped through* rather than browsed — you come back to the same three or four channels — so where you were last is worth more here than a catalogue is.

A rail above the line-up, ordered by when it was watched rather than by where the channel sits in the line-up, never repeating what is already pinned right above it, and bounded at twelve, because a history of everything ever watched is not a shortcut any more.

## A LIVE pill

Beside the title. It is the one thing that makes the screen read as live rather than as a grid of logos: it is on now, and there is nothing to resume to.

---

`flutter analyze` clean (one pre-existing info), 53 tests pass, all translation keys resolve in en/ru/uz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)