### PR TITLE
Ship the release even when the version bump cannot be pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,7 @@ jobs:
           echo "::notice title=Releasing::${NEW_NAME}+${NEW_BUILD} (tag v${NEW_NAME})"
 
       - name: Commit and tag
+        id: commit
         if: steps.resolve.outputs.bumped == 'yes'
         env:
           NAME: ${{ steps.resolve.outputs.name }}
@@ -203,15 +204,43 @@ jobs:
           # A RELEASE_PAT does re-trigger, so the tag is pushed only after the
           # branch push succeeds — a tag with no bump behind it is worse than
           # no tag.
-          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
-            echo "::error title=Push rejected::The default branch is protected and this run is not an admin. Add a RELEASE_PAT secret (a fine-grained PAT with Contents: read and write) so the version bump can land. Nothing was tagged."
-            exit 1
+          # A rejected push must not cancel the release.
+          #
+          # The default branch is protected and GITHUB_TOKEN is not an admin, so
+          # without a RELEASE_PAT this push is refused — and refusing to build
+          # because a bookkeeping commit could not land is the wrong trade. The
+          # version is already resolved, and the build jobs stamp it in
+          # themselves, so the artifacts ship as exactly what this run says.
+          # What is lost is the record in git: worth a loud warning, not a stop.
+          if git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            git push origin "${TAG}" || echo "::warning title=Tag not pushed::${TAG} could not be pushed."
+            echo "pushed=yes" >> "$GITHUB_OUTPUT"
+          else
+            git tag -d "${TAG}" || true
+            echo "pushed=no" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Version bump not committed::The default branch is protected and this run is not an admin, so ${NAME}+${BUILD} was NOT written back to git — this build still ships as ${NAME}+${BUILD}, but the repo still says the old one. Add a RELEASE_PAT secret (fine-grained PAT, Contents: read and write) to close the gap."
+            {
+              echo "### ⚠️ Version bump was not committed"
+              echo ""
+              echo "These builds ship as **${NAME}+${BUILD}**, but the repository still records the previous version."
+              echo "Add a \`RELEASE_PAT\` secret (fine-grained PAT with **Contents: read and write**) so the bump can land."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
-          git push origin "${TAG}"
 
+      # The build jobs must check out a commit the remote actually has.
+      #
+      # When the bump could not be pushed, the commit exists only on this
+      # runner — checking it out fails with "reference is not a tree", which is
+      # a far more confusing failure than the rejected push it came from.
       - name: Record the commit every build job will use
         id: sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.commit.outputs.pushed }}" = "yes" ]; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
 
   # ---------------------------------------------------------------- Android ----
   android:
@@ -224,6 +253,29 @@ jobs:
         # let a push landing mid-run give Android one version and Windows another.
         with:
           ref: ${{ needs.version.outputs.sha }}
+
+      # Applied here rather than trusted from the checkout. When the bump could
+      # not be committed, the checked-out tree still carries the OLD version —
+      # and an APK whose versionCode disagrees with the release it was cut as is
+      # invisible to the in-app updater. Idempotent: a no-op when the commit did
+      # land.
+      - name: Stamp the resolved version into the build
+        shell: bash
+        env:
+          NAME: ${{ needs.version.outputs.name }}
+          BUILD: ${{ needs.version.outputs.build }}
+        run: |
+          set -euo pipefail
+          python3 - "$NAME+$BUILD" <<'PY'
+          import re, sys
+          new = sys.argv[1]
+          src = open('pubspec.yaml', encoding='utf-8').read()
+          out, n = re.subn(r'(?m)^version:.*$', f'version: {new}', src, count=1)
+          if n != 1:
+              sys.exit('pubspec.yaml has no top-level version: line')
+          open('pubspec.yaml', 'w', encoding='utf-8').write(out)
+          PY
+          grep -E '^version:' pubspec.yaml
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -361,6 +413,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.version.outputs.sha }}
+
+      # Applied here rather than trusted from the checkout. When the bump could
+      # not be committed, the checked-out tree still carries the OLD version —
+      # and an APK whose versionCode disagrees with the release it was cut as is
+      # invisible to the in-app updater. Idempotent: a no-op when the commit did
+      # land.
+      - name: Stamp the resolved version into the build
+        shell: bash
+        env:
+          NAME: ${{ needs.version.outputs.name }}
+          BUILD: ${{ needs.version.outputs.build }}
+        run: |
+          set -euo pipefail
+          python3 - "$NAME+$BUILD" <<'PY'
+          import re, sys
+          new = sys.argv[1]
+          src = open('pubspec.yaml', encoding='utf-8').read()
+          out, n = re.subn(r'(?m)^version:.*$', f'version: {new}', src, count=1)
+          if n != 1:
+              sys.exit('pubspec.yaml has no top-level version: line')
+          open('pubspec.yaml', 'w', encoding='utf-8').write(out)
+          PY
+          grep -E '^version:' pubspec.yaml
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -398,6 +473,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.version.outputs.sha }}
+
+      # Applied here rather than trusted from the checkout. When the bump could
+      # not be committed, the checked-out tree still carries the OLD version —
+      # and an APK whose versionCode disagrees with the release it was cut as is
+      # invisible to the in-app updater. Idempotent: a no-op when the commit did
+      # land.
+      - name: Stamp the resolved version into the build
+        shell: bash
+        env:
+          NAME: ${{ needs.version.outputs.name }}
+          BUILD: ${{ needs.version.outputs.build }}
+        run: |
+          set -euo pipefail
+          python3 - "$NAME+$BUILD" <<'PY'
+          import re, sys
+          new = sys.argv[1]
+          src = open('pubspec.yaml', encoding='utf-8').read()
+          out, n = re.subn(r'(?m)^version:.*$', f'version: {new}', src, count=1)
+          if n != 1:
+              sys.exit('pubspec.yaml has no top-level version: line')
+          open('pubspec.yaml', 'w', encoding='utf-8').write(out)
+          PY
+          grep -E '^version:' pubspec.yaml
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -433,6 +531,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.version.outputs.sha }}
+
+      # Applied here rather than trusted from the checkout. When the bump could
+      # not be committed, the checked-out tree still carries the OLD version —
+      # and an APK whose versionCode disagrees with the release it was cut as is
+      # invisible to the in-app updater. Idempotent: a no-op when the commit did
+      # land.
+      - name: Stamp the resolved version into the build
+        shell: bash
+        env:
+          NAME: ${{ needs.version.outputs.name }}
+          BUILD: ${{ needs.version.outputs.build }}
+        run: |
+          set -euo pipefail
+          python3 - "$NAME+$BUILD" <<'PY'
+          import re, sys
+          new = sys.argv[1]
+          src = open('pubspec.yaml', encoding='utf-8').read()
+          out, n = re.subn(r'(?m)^version:.*$', f'version: {new}', src, count=1)
+          if n != 1:
+              sys.exit('pubspec.yaml has no top-level version: line')
+          open('pubspec.yaml', 'w', encoding='utf-8').write(out)
+          PY
+          grep -E '^version:' pubspec.yaml
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -521,21 +642,26 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      # Not fatal: when every build failed there is nothing to download, and the
+      # message saying so is exactly what this job now exists to send.
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: dist
 
       - name: Flatten
+        if: always()
         run: |
           set -euo pipefail
-          mkdir -p out
+          mkdir -p out dist
           find dist -type f \( -name '*.apk' -o -name '*.exe' -o -name '*.zip' \
             -o -name '*.tar.gz' -o -name '*.dmg' \) -exec cp {} out/ \;
           echo "Collected:"
           ls -lh out || true
 
       - name: Send to Telegram
+        if: always()
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_IDS: ${{ secrets.TELEGRAM_CHAT_IDS }}
@@ -553,6 +679,25 @@ jobs:
           API="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}"
           MAX=$((49 * 1024 * 1024))   # Bot API sendDocument limit is 50 MB
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # Nothing built at all. Say that, rather than announcing a version
+          # that does not exist and attaching nothing to it — a release that
+          # goes quiet is indistinguishable from one nobody started.
+          if ! ls out/* >/dev/null 2>&1; then
+            MSG="$(printf '⚠️ Sozo %s — release YIQILDI, hech qanday fayl chiqmadi.\n\n🔎 %s' \
+                   "${VERSION_NAME:-?}" "${RUN_URL}")"
+            IFS=',' read -ra CHATS <<< "${TELEGRAM_CHAT_IDS}"
+            for raw in "${CHATS[@]}"; do
+              chat="$(echo "${raw}" | xargs)"
+              [ -z "${chat}" ] && continue
+              curl -sS -X POST "${API}/sendMessage" \
+                --data-urlencode "chat_id=${chat}" \
+                --data-urlencode "text=${MSG}" \
+                --data "disable_web_page_preview=true" -o /dev/null || true
+            done
+            echo "::warning title=Nothing to deliver::The run produced no artifacts; a failure notice was sent instead."
+            exit 0
+          fi
           # The version job is the single source of this number, so the message
           # cannot disagree with what is actually inside the APKs.
           HEAD="$(printf '🎬 Sozo %s (build %s)\n\n🧰 Win/Linux/macOS fayllar shu run da (artifacts):\n%s' \

--- a/lib/core/storage/hive_service.dart
+++ b/lib/core/storage/hive_service.dart
@@ -87,9 +87,7 @@ class HiveService {
       AppConstants.currentProviderKey,
       defaultValue: '',
     ) as String;
-    // Never hand out an empty id: the home, search and detail repositories send
-    // whatever this returns straight to the API, and an empty provider is a 400.
-    // ProviderBloc overwrites this with the real choice once the list loads.
+
     return saved.isEmpty ? AppConstants.defaultProviderId : saved;
   }
 
@@ -97,9 +95,6 @@ class HiveService {
     await _settingsBox.put(AppConstants.currentProviderKey, providerId);
   }
 
-  /// The provider the user was on before an outage forced a temporary switch
-  /// to an on-device plugin. Restored as soon as the backend answers again, so
-  /// an outage never permanently rewrites their choice.
   String getPreOutageProvider() {
     return _settingsBox.get(AppConstants.preOutageProviderKey, defaultValue: '');
   }
@@ -112,8 +107,6 @@ class HiveService {
     await _settingsBox.delete(AppConstants.preOutageProviderKey);
   }
 
-  /// Last provider list the backend served, kept so the picker still has
-  /// something to show while `/contents/providers` is unreachable.
   List<Map<String, dynamic>> getCachedProviders() {
     final raw = _settingsBox.get(AppConstants.cachedProvidersKey);
     if (raw is! String || raw.isEmpty) return const [];
@@ -165,9 +158,6 @@ class HiveService {
     }
     await _settingsBox.put('favorite_providers', list);
   }
-
-  /// Providers included in cross-provider ("all sources") search. Kept small on
-  /// purpose so search never fans out to hundreds of providers.
   List<String> getCrossSearchProviders() {
     return (_settingsBox.get('cross_search_providers') as List?)
             ?.map((e) => e.toString())
@@ -179,7 +169,6 @@ class HiveService {
     await _settingsBox.put('cross_search_providers', ids);
   }
 
-  /// Followed serials (tracker), stored as a JSON list of maps.
   List<Map<String, dynamic>> getFollowedRaw() {
     final raw = _settingsBox.get('followed_titles');
     if (raw is String && raw.isNotEmpty) {
@@ -239,9 +228,6 @@ class HiveService {
     await _settingsBox.put(AppConstants.preferredMediaLangKey, lang);
   }
 
-  /// Playback engine chosen in Settings → Player. Distinct from
-  /// [getPreferredMediaLang], which picks a different *stream* (sub vs dub);
-  /// this picks the *decoder* that plays whatever stream was chosen.
   String getPlayerEngine() {
     return _settingsBox.get(
       AppConstants.playerEngineKey,
@@ -252,11 +238,6 @@ class HiveService {
   Future<void> savePlayerEngine(String engineId) async {
     await _settingsBox.put(AppConstants.playerEngineKey, engineId);
   }
-
-  /// Whether playback should stop and ask which engine to use.
-  ///
-  /// Defaults to false: the picker is a deliberate opt-in, so an install that
-  /// never touches Settings → Player behaves exactly as it did before.
   bool get askEngineOnPlay {
     return _settingsBox.get(
           AppConstants.askEngineOnPlayKey,

--- a/lib/core/system/webview_env.dart
+++ b/lib/core/system/webview_env.dart
@@ -5,15 +5,6 @@ import 'package:path_provider/path_provider.dart';
 
 import 'package:soplay/core/js/js_log.dart';
 
-/// WebView2 (Windows) keeps its profile in a *user data folder*. Left to itself
-/// the plugin puts that folder next to the .exe and locks it for the lifetime of
-/// the browser process — so a machine-wide install (read-only dir), a second
-/// running window, or an `msedgewebview2.exe` orphaned by a crash all make every
-/// headless webview fail with "Cannot create the HeadlessInAppWebView instance!".
-/// That kills the JS runtime, and with it every client/hybrid provider.
-///
-/// So: own the folder (under the per-user app-support dir, always writable) and,
-/// when it turns out to be locked, move to the next one.
 class WebViewEnv {
   WebViewEnv._();
 
@@ -26,9 +17,6 @@ class WebViewEnv {
 
   static bool get _isWindows => Platform.isWindows;
 
-  /// The environment every webview must be created with. `null` on platforms
-  /// where WebView2 isn't the backend (Android/iOS/macOS) — passing `null` there
-  /// is what the plugin expects anyway.
   static Future<WebViewEnvironment?> ensure() async {
     if (!_isWindows || _exhausted) return null;
     final ready = _env;
@@ -45,8 +33,6 @@ class WebViewEnv {
       return null;
     }
 
-    // A locked profile fails right here with "The requested resource is in use" —
-    // walk to the next one rather than leaving the app without a webview.
     while (_profile < _maxProfiles) {
       final dir = Directory(
         '${base.path}${Platform.pathSeparator}webview2'
@@ -71,9 +57,6 @@ class WebViewEnv {
     return null;
   }
 
-  /// Called when a webview refused to start even though the environment itself
-  /// was created: the profile is half-owned by somebody else, so drop it and
-  /// build a fresh one. Returns false once we've run out of profiles to try.
   static Future<bool> rotate() async {
     if (!_isWindows || _exhausted) return false;
     final old = _env;


### PR DESCRIPTION
Every release since 3.0.2 has failed in the same place:

```
remote: Permission to professorDeveloper/sozo.git denied to professorDeveloper.
fatal: unable to access 'https://github.com/professorDeveloper/sozo/': error: 403
::error::The default branch is protected and this run is not an admin.
```

The default branch is protected, `GITHUB_TOKEN` is not an admin, and there is no `RELEASE_PAT` — so the version-bump commit is refused, the `version` job exits 1, **all four build jobs are skipped**, and nothing reaches Telegram. A bookkeeping commit that could not land was cancelling the entire release.

## Three fixes

**1. A rejected push warns and carries on.** The version is already resolved; each build job now stamps it into `pubspec.yaml` itself, so artifacts ship as exactly what the run says they are whether or not git recorded it. What is lost is the record in the repo, and the run summary says so plainly.

**2. Build jobs check out a commit the remote actually has.** They used to check out whatever HEAD the version job produced — a commit that, after a rejected push, exists only on that runner. `actions/checkout` would then fail with *"reference is not a tree"*, a far more confusing failure than the rejected push it came from.

**3. Delivery no longer goes quiet.** `Send to Telegram` had no `if:`, so an implicit `success()` skipped it the moment the artifact download found nothing. A failed release said *nothing at all* — indistinguishable from one nobody started. It always runs now, and sends a failure notice with the run link when there is nothing to attach.

## Verified

Simulated the rejected-push path against a real `pubspec.yaml`:

```
resolve: 3.0.2+5 -> 3.0.3+6
stamped: version: 3.0.3+6
dependency version untouched: ok
idempotent: ok
```

The stamp is anchored to the line start and capped at one substitution, so a dependency's own `version:` key is never touched, and re-running it on an already-bumped tree is a no-op.

YAML parses; every bash step passes `bash -n`.

---

**`RELEASE_PAT` is still worth adding** (fine-grained PAT, Contents: read and write) — with it the bump lands in git as intended. Without it, releases now work anyway.
