### PR TITLE
Swallow the ad hosts the server names

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -347,7 +347,6 @@ Future<void> configureDependencies() async {
       mangayomi: getIt<MangayomiBridge>(),
       jsRuntime: getIt<JsRuntimeService>(),
       hive: getIt<HiveService>(),
-      webViewExtractor: getIt<WebViewStreamExtractor>(),
     ),
   );
   getIt.registerSingleton<CommentsDataSource>(

--- a/lib/core/player/webview_stream_extractor.dart
+++ b/lib/core/player/webview_stream_extractor.dart
@@ -188,6 +188,14 @@ class WebViewStreamExtractor {
     final userAgent = _mobileUserAgent;
     final referer = _headerValue(pageHeaders, 'Referer');
 
+    // Baseline noise plus whatever this source declared. Server-supplied hosts are
+    // additive: the directive names the ad slot THIS embed pulls in, and the
+    // baseline covers the trackers every page has.
+    final blockFragments = <String>[
+      ..._blockHostFragments,
+      ...config.blockHosts.map((h) => h.toLowerCase()),
+    ];
+
     if (kDebugMode) {
       debugPrint(
         '[WebViewExtractor] start page=$pageUrl host=${config.hostPattern} '
@@ -306,7 +314,7 @@ class WebViewStreamExtractor {
           );
         }
 
-        if (_blockHostFragments.any((frag) => lowerUrl.contains(frag))) {
+        if (blockFragments.any((frag) => lowerUrl.contains(frag))) {
           return WebResourceResponse(
             contentType: 'text/plain',
             statusCode: 200,

--- a/lib/features/detail/data/models/media_resolve_model.dart
+++ b/lib/features/detail/data/models/media_resolve_model.dart
@@ -51,6 +51,9 @@ class MediaResolveModel extends MediaResolveEntity {
     final headers = (raw['captureHeaders'] as List? ?? const [])
         .whereType<String>()
         .toList(growable: false);
+    final blockHosts = (raw['blockHosts'] as List? ?? const [])
+        .whereType<String>()
+        .toList(growable: false);
     final timeout = raw['timeoutMs'];
     final loginUrl = raw['loginUrl'] as String?;
     final playType = (raw['playType'] as String?)?.toLowerCase();
@@ -59,6 +62,7 @@ class MediaResolveModel extends MediaResolveEntity {
       hostPattern: hostPattern,
       urlPatterns: patterns,
       captureHeaders: headers,
+      blockHosts: blockHosts,
       timeoutMs: timeout is num ? timeout.toInt() : 20000,
       loginUrl: loginUrl != null && loginUrl.isNotEmpty ? loginUrl : null,
       playType: playType == null || playType.isEmpty ? 'hls' : playType,

--- a/lib/features/detail/data/repositories/detail_repository_impl.dart
+++ b/lib/features/detail/data/repositories/detail_repository_impl.dart
@@ -8,7 +8,6 @@ import 'package:soplay/core/error/result.dart';
 import 'package:soplay/core/js/js_runtime_service.dart';
 import 'package:soplay/features/manga/data/models/manga_pages_model.dart';
 import 'package:soplay/features/manga/domain/entities/manga_pages_entity.dart';
-import 'package:soplay/core/player/webview_stream_extractor.dart';
 import 'package:soplay/core/storage/hive_service.dart';
 import 'package:soplay/features/detail/data/datasources/detail_data_source.dart';
 import 'package:soplay/features/detail/data/models/detail_model.dart';
@@ -23,14 +22,12 @@ class DetailRepositoryImpl implements DetailRepository {
   final DetailDataSource dataSource;
   final JsRuntimeService? jsRuntime;
   final HiveService? hive;
-  final WebViewStreamExtractor? webViewExtractor;
 
   const DetailRepositoryImpl(
     this.dataSource, {
     required this.mangayomi,
     this.jsRuntime,
     this.hive,
-    this.webViewExtractor,
   });
 
   final MangayomiBridge mangayomi;

--- a/lib/features/detail/domain/entities/extractor_config_entity.dart
+++ b/lib/features/detail/domain/entities/extractor_config_entity.dart
@@ -3,6 +3,11 @@ class ExtractorConfigEntity {
   final String hostPattern;
   final List<String> urlPatterns;
   final List<String> captureHeaders;
+
+  /// Ad/analytics hosts to swallow so the page settles and no ad creative is
+  /// mistaken for the feature. Server-supplied, on top of the extractor's own
+  /// baseline list — the app must not need to know which site it is talking to.
+  final List<String> blockHosts;
   final int timeoutMs;
   final String? loginUrl;
   final String playType;
@@ -12,6 +17,7 @@ class ExtractorConfigEntity {
     required this.urlPatterns,
     this.mode = 'shouldInterceptRequest',
     this.captureHeaders = const [],
+    this.blockHosts = const [],
     this.timeoutMs = 20000,
     this.loginUrl,
     this.playType = 'hls',


### PR DESCRIPTION
The extractor directive carries a block list so the app never has to know
which site it is talking to. We parsed every other field in that directive
and ignored this one.

That left the sniffer on its own baseline of trackers — which covers what
every page pulls in, and not the ad slot a particular embed pulls in. That
slot serves an `.mp4`, and an `.mp4` landing before the real manifest is
what gets played.

## What changed

- `ExtractorConfigEntity` gains `blockHosts`; `MediaResolveModel` parses it.
- The sniffer merges server hosts **on top of** its baseline rather than
  replacing it, so a directive naming one host cannot switch the trackers
  back on.
- Drops `DetailRepositoryImpl`'s `WebViewStreamExtractor` field — it was
  constructor-injected and never read. The sniff happens in the player
  page, which resolves the singleton itself. The registration stays.

## Depends on

professorDeveloper/sozo-backend#22 — that PR starts sending `blockHosts`
on the `extractor` directive. Merge it first.

## Testing

`flutter analyze` clean. Playback on a real device is **not** verified;
RareAnimes is still flagged unplayable server-side.